### PR TITLE
test: MemberService 테스트 코드 작성

### DIFF
--- a/src/test/java/me/washcar/wcnc/domain/member/MemberTestHelper.java
+++ b/src/test/java/me/washcar/wcnc/domain/member/MemberTestHelper.java
@@ -59,4 +59,24 @@ public class MemberTestHelper {
 			.build();
 	}
 
+	public Member makeActiveMember() {
+		return makeRandomMember();
+	}
+
+	public Member makeInactiveMember() {
+		String prefix = "RandomMember-";
+		String randomName = prefix.concat(generateRandomName());
+		String randomPassword = prefix.concat(generateRandomPassword());
+		String randomTelephone = generateRandomTelephone();
+		return Member.builder()
+			.name(randomName)
+			.memberRole(USER)
+			.memberStatus(MemberStatus.INACTIVE)
+			.memberAuthenticationType(MemberAuthenticationType.PASSWORD)
+			.password(randomPassword)
+			.telephone(randomTelephone)
+			.stores(new ArrayList<>())
+			.reservations(new ArrayList<>())
+			.build();
+	}
 }

--- a/src/test/java/me/washcar/wcnc/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/me/washcar/wcnc/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,258 @@
+package me.washcar.wcnc.domain.member.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import me.washcar.wcnc.domain.member.Member;
+import me.washcar.wcnc.domain.member.MemberStatus;
+import me.washcar.wcnc.domain.member.MemberTestHelper;
+import me.washcar.wcnc.domain.member.dao.MemberRepository;
+import me.washcar.wcnc.global.error.BusinessException;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+	@Mock
+	private MemberRepository memberRepository;
+	@Mock
+	private ModelMapper modelMapper;
+	private MemberTestHelper memberTestHelper;
+	private MemberService memberService;
+
+	@BeforeEach
+	void setUp() {
+		memberService = new MemberService(memberRepository, modelMapper);
+		memberTestHelper = new MemberTestHelper();
+	}
+
+	@Test
+	@Disabled
+	void postMember() {
+		//TODO 미구현
+	}
+
+	@Nested
+	@DisplayName("멤버 목록 가져오기")
+	class getMemberList {
+
+		@Test
+		@DisplayName("page와 size가 정상 범위인 경우 Pageable역시 동일한 값을 가진다")
+		void should_pageableIsCorrect_when_pageAndSizesAreInCorrectRange() {
+			//given
+			int page = 0;
+			int size = 5;
+			Pageable pageable = PageRequest.of(page, size);
+			Page<Member> memberPage = Mockito.mock(Page.class);
+			when(memberRepository.findAll(pageable)).thenReturn(memberPage);
+
+			//when
+			memberService.getMemberList(page, size);
+
+			//then
+			ArgumentCaptor<Pageable> pageableArgumentCaptor = ArgumentCaptor.forClass(Pageable.class);
+			verify(memberRepository).findAll(pageableArgumentCaptor.capture());
+			Pageable capturedPageable = pageableArgumentCaptor.getValue();
+			assertThat(capturedPageable.getPageNumber()).isEqualTo(page);
+			assertThat(capturedPageable.getPageSize()).isEqualTo(size);
+		}
+
+	}
+
+	@Nested
+	@DisplayName("UUID로 멤버 가져오기")
+	class getMemberByUuid {
+
+		@Test
+		@DisplayName("멤버가 존재하는 경우 멤버 가져오기에 성공한다")
+		void should_successGetMember_when_memberExist() {
+			//given
+			Member member = memberTestHelper.makeRandomMember();
+			given(memberRepository.findByUuid(member.getUuid())).willReturn(Optional.of(member));
+
+			//when
+			memberService.getMemberByUuid(member.getUuid());
+
+			//then
+			ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
+			verify(memberRepository).findByUuid(stringArgumentCaptor.capture());
+			String capturedString = stringArgumentCaptor.getValue();
+			assertThat(capturedString).isEqualTo(member.getUuid());
+
+			ArgumentCaptor<Member> memberArgumentCaptor = ArgumentCaptor.forClass(Member.class);
+			verify(modelMapper).map(memberArgumentCaptor.capture(), any(Class.class));
+			Member capturedMember = memberArgumentCaptor.getValue();
+			assertThat(capturedMember).isEqualTo(member);
+		}
+
+		@Test
+		@DisplayName("멤버가 존재하지 않는 경우 에러를 반환한다")
+		void should_errorGetMember_when_memberNotExist() {
+			//given
+			given(memberRepository.findByUuid(anyString())).willReturn(Optional.empty());
+
+			//when & then
+			assertThatThrownBy(() -> memberService.getMemberByUuid(UUID.randomUUID().toString()))
+				.isInstanceOf(BusinessException.class);
+		}
+
+	}
+
+	@Test
+	@Disabled
+	void putMemberByUuid() {
+		//TODO 미구현
+	}
+
+	@Nested
+	@DisplayName("UUID로 멤버 삭제하기")
+	class deleteMemberByUuid {
+
+		@Test
+		@DisplayName("멤버가 존재하는 경우 멤버 삭제하기에 성공한다")
+		void should_successDeleteMember_when_memberExist() {
+			//given
+			Member member = memberTestHelper.makeRandomMember();
+			given(memberRepository.findByUuid(member.getUuid())).willReturn(Optional.of(member));
+
+			//when
+			memberService.deleteMemberByUuid(member.getUuid());
+
+			//then
+			ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
+			verify(memberRepository).findByUuid(stringArgumentCaptor.capture());
+			String capturedString = stringArgumentCaptor.getValue();
+			assertThat(capturedString).isEqualTo(member.getUuid());
+
+			ArgumentCaptor<Member> memberArgumentCaptor = ArgumentCaptor.forClass(Member.class);
+			verify(memberRepository).delete(memberArgumentCaptor.capture());
+			Member capturedMember = memberArgumentCaptor.getValue();
+			assertThat(capturedMember).isEqualTo(member);
+		}
+
+		@Test
+		@DisplayName("멤버가 존재하지 않는 경우 에러를 반환한다")
+		void should_errorDeleteMember_when_memberNotExist() {
+			//given
+			given(memberRepository.findByUuid(anyString())).willReturn(Optional.empty());
+
+			//when & then
+			assertThatThrownBy(() -> memberService.deleteMemberByUuid(UUID.randomUUID().toString()))
+				.isInstanceOf(BusinessException.class);
+			verify(memberRepository, never()).delete(any());
+		}
+
+	}
+
+	@Nested
+	@DisplayName("UUID로 멤버 상태 변경하기")
+	class changeMemberStatusByUuid {
+
+		@Test
+		@DisplayName("멤버가 활성 상태인 경우 멤버 비활성에 성공한다")
+		void should_inactivateMember_when_memberIsActive() {
+			//given
+			Member member = memberTestHelper.makeActiveMember();
+			given(memberRepository.findByUuid(member.getUuid())).willReturn(Optional.of(member));
+
+			//when
+			memberService.changeMemberStatusByUuid(member.getUuid(), MemberStatus.INACTIVE);
+
+			//then
+			ArgumentCaptor<Member> memberArgumentCaptor = ArgumentCaptor.forClass(Member.class);
+			verify(memberRepository).save(memberArgumentCaptor.capture());
+			Member capturedMember = memberArgumentCaptor.getValue();
+			assertThat(capturedMember.getUuid()).isEqualTo(member.getUuid());
+			assertThat(capturedMember.getMemberStatus()).isEqualTo(MemberStatus.INACTIVE);
+		}
+
+		@Test
+		@DisplayName("멤버가 활성 상태인 경우에도 멤버 활성에 성공한다")
+		void should_activateMember_when_memberIsActive() {
+			//given
+			Member member = memberTestHelper.makeActiveMember();
+			given(memberRepository.findByUuid(member.getUuid())).willReturn(Optional.of(member));
+
+			//when
+			memberService.changeMemberStatusByUuid(member.getUuid(), MemberStatus.ACTIVE);
+
+			//then
+			ArgumentCaptor<Member> memberArgumentCaptor = ArgumentCaptor.forClass(Member.class);
+			verify(memberRepository).save(memberArgumentCaptor.capture());
+			Member capturedMember = memberArgumentCaptor.getValue();
+			assertThat(capturedMember.getUuid()).isEqualTo(member.getUuid());
+			assertThat(capturedMember.getMemberStatus()).isEqualTo(MemberStatus.ACTIVE);
+		}
+
+		@Test
+		@DisplayName("멤버가 비활성 상태인 경우 멤버 활성에 성공한다")
+		void should_activateMember_when_memberIsInactive() {
+			//given
+			Member member = memberTestHelper.makeInactiveMember();
+			given(memberRepository.findByUuid(member.getUuid())).willReturn(Optional.of(member));
+
+			//when
+			memberService.changeMemberStatusByUuid(member.getUuid(), MemberStatus.ACTIVE);
+
+			//then
+			ArgumentCaptor<Member> memberArgumentCaptor = ArgumentCaptor.forClass(Member.class);
+			verify(memberRepository).save(memberArgumentCaptor.capture());
+			Member capturedMember = memberArgumentCaptor.getValue();
+			assertThat(capturedMember.getUuid()).isEqualTo(member.getUuid());
+			assertThat(capturedMember.getMemberStatus()).isEqualTo(MemberStatus.ACTIVE);
+		}
+
+		@Test
+		@DisplayName("멤버가 비활성 상태인 경우에도 멤버 비활성에 성공한다")
+		void should_inactivateMember_when_memberIsInactive() {
+			//given
+			Member member = memberTestHelper.makeInactiveMember();
+			given(memberRepository.findByUuid(member.getUuid())).willReturn(Optional.of(member));
+
+			//when
+			memberService.changeMemberStatusByUuid(member.getUuid(), MemberStatus.INACTIVE);
+
+			//then
+			ArgumentCaptor<Member> memberArgumentCaptor = ArgumentCaptor.forClass(Member.class);
+			verify(memberRepository).save(memberArgumentCaptor.capture());
+			Member capturedMember = memberArgumentCaptor.getValue();
+			assertThat(capturedMember.getUuid()).isEqualTo(member.getUuid());
+			assertThat(capturedMember.getMemberStatus()).isEqualTo(MemberStatus.INACTIVE);
+		}
+
+		@Test
+		@DisplayName("멤버가 존재하지 않는 경우 에러를 반환한다")
+		void should_errorInactivateMember_when_memberNotExist() {
+			//given
+			given(memberRepository.findByUuid(anyString())).willReturn(Optional.empty());
+
+			//when & then
+			assertThatThrownBy(
+				() -> memberService.changeMemberStatusByUuid(UUID.randomUUID().toString(), MemberStatus.INACTIVE))
+				.isInstanceOf(BusinessException.class);
+		}
+
+	}
+
+	@Test
+	@Disabled
+	void getMemberByJwt() {
+		//TODO 미구현
+	}
+}


### PR DESCRIPTION
## 🔥 관련 이슈

없음

## 📝 작업 상세 설명

Mockito를 활용한 단위 테스트 작성. @SpringBootTest 를 사용하지 않음으로써 테스트 로딩 시간을 줄이고자 하였습니다.
TODO 주석이 있는 테스트 코드는 아직 미구현 기능들에 대한 더미입니다.

## ⭐ 리뷰 요구 사항

ArgumentCaptor 생성 > verify() > captor.getValue() > asserThat() 
```
  ArgumentCaptor<Member> memberArgumentCaptor = ArgumentCaptor.forClass(Member.class);
  verify(memberRepository).save(memberArgumentCaptor.capture());
  Member capturedMember = memberArgumentCaptor.getValue();
  assertThat(capturedMember.getUuid()).isEqualTo(member.getUuid());
```
으로 진행되는 사이클을 줄이거나 함수화 할 방법이 있을까요?
