### PR TITLE
fix: 빌드 도중의 hibernate deprecated setting 경고 해결

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,13 @@ server:
   port: 80
 
 spring:
+  jpa:
+    properties:
+      jakarta:
+        persistence:
+          sharedCache:
+            mode: ALL
+
   datasource:
     url: ${SPRING_DATASOURCE_URL}
     username: ${SPRING_DATASOURCE_USERNAME}


### PR DESCRIPTION
## 🔥 관련 이슈

없음

## 📝 작업 상세 설명

빌드 도중 생기는 다음 경고 알림이 일어나지 않도록 프로퍼티 파일을 변경하였습니다. 
```
WARN 15718 --- [restartedMain] org.hibernate.orm.deprecation: HHH90000021: Encountered deprecated setting [javax.persistence.sharedCache.mode], use [jakarta.persistence.sharedCache.mode] instead
```
해당 옵션이 지정되어있지 않은 경우의 기본값이 "UNSPECIFIED" 이기에 hibernate 가 javax 와 jarkarta 세팅을 모두 확인하여 값을 지정하려는 오류입니다. 값을 ALL로 지정함으로써 캐싱을 시킴과 동시에 (원하지 않으면 NONE으로 지정해도 되지만, 하는 편이 좋은 것 같습니다.) javax 세팅값을 조회하는 코드가 실행되지 않도록 했습니다.

장기적으로는 hibernate 측에서 문제를 해결 할 수도 있을 것 같습니다.

참고: https://github.com/spring-projects/spring-data-jpa/issues/2717#issuecomment-1339586944

## ⭐ 리뷰 요구 사항

없음