### PR TITLE
refactor: Member 도메인 리팩토링

### DIFF
--- a/src/main/java/me/washcar/wcnc/domain/member/controller/MemberController.java
+++ b/src/main/java/me/washcar/wcnc/domain/member/controller/MemberController.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,6 +20,8 @@ import me.washcar.wcnc.domain.member.MemberStatus;
 import me.washcar.wcnc.domain.member.dto.request.MemberPatchRequestDto;
 import me.washcar.wcnc.domain.member.dto.response.MemberDto;
 import me.washcar.wcnc.domain.member.service.MemberService;
+import me.washcar.wcnc.global.definition.Regex;
+import me.washcar.wcnc.global.definition.RegexMessage;
 
 @RestController
 @RequestMapping("/v2/member")
@@ -28,17 +29,7 @@ import me.washcar.wcnc.domain.member.service.MemberService;
 @Validated
 public class MemberController {
 
-	private static final String REGEXP_UUID_V4 = "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$";
-
 	private final MemberService memberService;
-
-	@PostMapping
-	public ResponseEntity<Void> postMember() {
-		memberService.postMember();
-		return ResponseEntity
-			.status(HttpStatus.NO_CONTENT)
-			.build();
-	}
 
 	@GetMapping
 	public ResponseEntity<Page<MemberDto>> getMemberList(
@@ -50,21 +41,24 @@ public class MemberController {
 	}
 
 	@GetMapping("/{uuid}")
-	public ResponseEntity<MemberDto> getMemberByUuid(@PathVariable @Pattern(regexp = REGEXP_UUID_V4) String uuid) {
+	public ResponseEntity<MemberDto> getMemberByUuid(
+		@PathVariable @Pattern(regexp = Regex.UUID_V4, message = RegexMessage.UUID_V4) String uuid) {
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.body(memberService.getMemberByUuid(uuid));
 	}
 
 	@PutMapping("/{uuid}")
-	public ResponseEntity<MemberDto> putMemberByUuid(@PathVariable @Pattern(regexp = REGEXP_UUID_V4) String uuid) {
+	public ResponseEntity<MemberDto> putMemberByUuid(
+		@PathVariable @Pattern(regexp = Regex.UUID_V4, message = RegexMessage.UUID_V4) String uuid) {
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.body(memberService.putMemberByUuid(uuid));
 	}
 
 	@DeleteMapping("/{uuid}")
-	public ResponseEntity<Void> deleteMemberByUuid(@PathVariable @Pattern(regexp = REGEXP_UUID_V4) String uuid) {
+	public ResponseEntity<Void> deleteMemberByUuid(
+		@PathVariable @Pattern(regexp = Regex.UUID_V4, message = RegexMessage.UUID_V4) String uuid) {
 		memberService.deleteMemberByUuid(uuid);
 		return ResponseEntity
 			.status(HttpStatus.NO_CONTENT)
@@ -73,7 +67,7 @@ public class MemberController {
 
 	@PatchMapping("/{uuid}")
 	public ResponseEntity<Void> patchMemberByUuid(
-		@PathVariable @Pattern(regexp = REGEXP_UUID_V4) String uuid,
+		@PathVariable @Pattern(regexp = Regex.UUID_V4, message = RegexMessage.UUID_V4) String uuid,
 		@RequestBody MemberPatchRequestDto memberPatchRequestDto) {
 		MemberStatus memberStatus = memberPatchRequestDto.getMemberStatus();
 		memberService.changeMemberStatusByUuid(uuid, memberStatus);

--- a/src/main/java/me/washcar/wcnc/domain/member/service/MemberService.java
+++ b/src/main/java/me/washcar/wcnc/domain/member/service/MemberService.java
@@ -1,16 +1,12 @@
 package me.washcar.wcnc.domain.member.service;
 
-import static me.washcar.wcnc.domain.member.MemberRole.*;
-
 import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
-import me.washcar.wcnc.domain.member.MemberAuthenticationType;
 import me.washcar.wcnc.domain.member.MemberStatus;
 import me.washcar.wcnc.domain.member.dao.MemberRepository;
 import me.washcar.wcnc.domain.member.dto.response.MemberDto;
@@ -24,24 +20,6 @@ public class MemberService {
 
 	private final MemberRepository memberRepository;
 	private final ModelMapper modelMapper;
-	private final PasswordEncoder passwordEncoder;
-
-	public void postMember() {
-		//TODO 추후 회원가입 로직으로 변경 필요
-
-		//멤버 더미를 DB에 추가하는 로직
-		Member randomMember = Member.builder()
-			.loginId("admin")
-			.nickname("Gilteun")
-			.memberRole(ROLE_USER)
-			.memberStatus(MemberStatus.ACTIVE)
-			.memberAuthenticationType(MemberAuthenticationType.PASSWORD)
-			.loginPassword(passwordEncoder.encode("password"))
-			.telephone("01022223333")
-			.build();
-
-		memberRepository.save(randomMember);
-	}
 
 	public Page<MemberDto> getMemberList(int page, int size) {
 		Pageable pageable = PageRequest.of(page, size);
@@ -76,8 +54,4 @@ public class MemberService {
 		memberRepository.save(member);
 	}
 
-	public MemberDto getMemberByJwt() {
-		//TODO 미구현: 내 쿠키(토큰) 기반 정보 조회
-		return null;
-	}
 }

--- a/src/main/java/me/washcar/wcnc/global/definition/Regex.java
+++ b/src/main/java/me/washcar/wcnc/global/definition/Regex.java
@@ -13,4 +13,7 @@ public class Regex {
 	public static final String SLUG = "^[a-zA-Z0-9-]{4,32}$";
 
 	public static final String NAME = "^[a-zA-Z0-9가-힇_-]{1,12}$";
+
+	public static final String UUID_V4 = "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$";
+
 }

--- a/src/main/java/me/washcar/wcnc/global/definition/RegexMessage.java
+++ b/src/main/java/me/washcar/wcnc/global/definition/RegexMessage.java
@@ -14,4 +14,6 @@ public class RegexMessage {
 
 	public static final String NAME = "닉네임은 1~12자의 영문, 한글, 숫자, -, _ 만 사용 가능합니다.";
 
+	public static final String UUID_V4 = "고유 식별번호는 UUID 버전 4 형식이어야 합니다.";
+
 }

--- a/src/test/java/me/washcar/wcnc/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/me/washcar/wcnc/domain/member/service/MemberServiceTest.java
@@ -20,12 +20,11 @@ import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
-import me.washcar.wcnc.domain.member.entity.Member;
 import me.washcar.wcnc.domain.member.MemberStatus;
 import me.washcar.wcnc.domain.member.MemberTestHelper;
 import me.washcar.wcnc.domain.member.dao.MemberRepository;
+import me.washcar.wcnc.domain.member.entity.Member;
 import me.washcar.wcnc.global.error.BusinessException;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,7 +38,7 @@ class MemberServiceTest {
 
 	@BeforeEach
 	void setUp() {
-		memberService = new MemberService(memberRepository, modelMapper, new BCryptPasswordEncoder());
+		memberService = new MemberService(memberRepository, modelMapper);
 		memberTestHelper = new MemberTestHelper();
 	}
 


### PR DESCRIPTION
## 🔥 관련 이슈

없음

## 📝 작업 상세 설명

Auth 도메인으로 이전되어 필요 없어진 Member 도메인 기능(postMember, getMemberByJwt) 들을 삭제함. 컨트롤러의 정규표현식 선언을 definition 속 별도 클래스로 이동, 에러메세지 추가.

## ⭐ 리뷰 요구 사항

`RegexMessage.UUID_V4` 안내 메세지 더 나은 게 있으면 추천 부탁드립니다.
