### PR TITLE
Feature/store api

### DIFF
--- a/src/main/java/me/washcar/wcnc/domain/member/entity/Member.java
+++ b/src/main/java/me/washcar/wcnc/domain/member/entity/Member.java
@@ -83,4 +83,18 @@ public class Member extends UuidEntity {
 		this.loginPassword = loginPassword;
 		this.telephone = telephone;
 	}
+
+	public void promote(MemberRole memberRole) {
+		if (this.memberRole.ordinal() < memberRole.ordinal()) {
+			this.memberRole = memberRole;
+		}
+	}
+
+	public void demote(MemberRole memberRole) {
+		if (this.memberRole.ordinal() > memberRole.ordinal()) {
+			this.memberRole = memberRole;
+		}
+	}
+
 }
+

--- a/src/main/java/me/washcar/wcnc/domain/store/controller/StoreController.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/controller/StoreController.java
@@ -1,0 +1,93 @@
+package me.washcar.wcnc.domain.store.controller;
+
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import lombok.RequiredArgsConstructor;
+import me.washcar.wcnc.domain.store.StoreStatus;
+import me.washcar.wcnc.domain.store.dto.request.StorePatchRequestDto;
+import me.washcar.wcnc.domain.store.dto.request.StoreRequestDto;
+import me.washcar.wcnc.domain.store.dto.response.StoreDto;
+import me.washcar.wcnc.domain.store.service.StoreService;
+import me.washcar.wcnc.global.definition.Regex;
+import me.washcar.wcnc.global.definition.RegexMessage;
+
+@RestController
+@RequestMapping("/v2/store")
+@RequiredArgsConstructor
+@Validated
+public class StoreController {
+	
+	private final StoreService storeService;
+
+	@PostMapping
+	public ResponseEntity<Void> postStore(
+		@RequestBody @Valid StoreRequestDto storeRequestDto, @AuthenticationPrincipal String uuid) {
+		storeService.postStore(storeRequestDto, uuid);
+		return ResponseEntity
+			.status(HttpStatus.NO_CONTENT)
+			.build();
+	}
+
+	@GetMapping
+	public ResponseEntity<Page<StoreDto>> getStoreList(
+		@RequestParam("page") int page,
+		@RequestParam("size") int size) {
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(storeService.getStoreList(page, size));
+	}
+
+	@GetMapping("/{slug}")
+	public ResponseEntity<StoreDto> getStoreBySlug(
+		@PathVariable @Pattern(regexp = Regex.SLUG, message = RegexMessage.SLUG) String slug) {
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(storeService.getStoreBySlug(slug));
+	}
+
+	@PutMapping("/{slug}")
+	public ResponseEntity<StoreDto> putStoreBySlug(
+		@PathVariable @Pattern(regexp = Regex.SLUG, message = RegexMessage.SLUG) String slug,
+		@RequestBody StoreRequestDto storeRequestDto) {
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(storeService.putStoreBySlug(slug, storeRequestDto));
+	}
+
+	@DeleteMapping("/{slug}")
+	public ResponseEntity<Void> deleteStoreBySlug(
+		@PathVariable @Pattern(regexp = Regex.SLUG, message = RegexMessage.SLUG) String slug) {
+		storeService.deleteStoreBySlug(slug);
+		return ResponseEntity
+			.status(HttpStatus.NO_CONTENT)
+			.build();
+	}
+
+	@PatchMapping("/{slug}")
+	public ResponseEntity<Void> patchStoreBySlug(
+		@PathVariable @Pattern(regexp = Regex.SLUG, message = RegexMessage.SLUG) String slug,
+		@RequestBody StorePatchRequestDto storePatchRequestDto) {
+		StoreStatus storeStatus = storePatchRequestDto.getStoreStatus();
+		storeService.changeStoreStatusBySlug(slug, storeStatus);
+		return ResponseEntity
+			.status(HttpStatus.NO_CONTENT)
+			.build();
+	}
+
+}

--- a/src/main/java/me/washcar/wcnc/domain/store/controller/StoreController.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/controller/StoreController.java
@@ -32,7 +32,7 @@ import me.washcar.wcnc.global.definition.RegexMessage;
 @RequiredArgsConstructor
 @Validated
 public class StoreController {
-	
+
 	private final StoreService storeService;
 
 	@PostMapping
@@ -40,7 +40,7 @@ public class StoreController {
 		@RequestBody @Valid StoreRequestDto storeRequestDto, @AuthenticationPrincipal String uuid) {
 		storeService.postStore(storeRequestDto, uuid);
 		return ResponseEntity
-			.status(HttpStatus.NO_CONTENT)
+			.status(HttpStatus.CREATED)
 			.build();
 	}
 
@@ -66,7 +66,7 @@ public class StoreController {
 		@PathVariable @Pattern(regexp = Regex.SLUG, message = RegexMessage.SLUG) String slug,
 		@RequestBody StoreRequestDto storeRequestDto) {
 		return ResponseEntity
-			.status(HttpStatus.OK)
+			.status(HttpStatus.CREATED)
 			.body(storeService.putStoreBySlug(slug, storeRequestDto));
 	}
 
@@ -86,7 +86,7 @@ public class StoreController {
 		StoreStatus storeStatus = storePatchRequestDto.getStoreStatus();
 		storeService.changeStoreStatusBySlug(slug, storeStatus);
 		return ResponseEntity
-			.status(HttpStatus.NO_CONTENT)
+			.status(HttpStatus.CREATED)
 			.build();
 	}
 

--- a/src/main/java/me/washcar/wcnc/domain/store/dao/StoreRepository.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/dao/StoreRepository.java
@@ -1,0 +1,19 @@
+package me.washcar.wcnc.domain.store.dao;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.washcar.wcnc.domain.store.entity.Store;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+
+	Page<Store> findAll(Pageable pageable);
+
+	Optional<Store> findBySlug(String slug);
+
+	boolean existsBySlug(String slug);
+
+}

--- a/src/main/java/me/washcar/wcnc/domain/store/dto/request/StorePatchRequestDto.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/dto/request/StorePatchRequestDto.java
@@ -1,0 +1,12 @@
+package me.washcar.wcnc.domain.store.dto.request;
+
+import lombok.Getter;
+import me.washcar.wcnc.domain.store.StoreStatus;
+
+@Getter
+@SuppressWarnings("unused")
+public class StorePatchRequestDto {
+
+	private StoreStatus storeStatus;
+
+}

--- a/src/main/java/me/washcar/wcnc/domain/store/dto/request/StoreRequestDto.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/dto/request/StoreRequestDto.java
@@ -1,0 +1,27 @@
+package me.washcar.wcnc.domain.store.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import me.washcar.wcnc.domain.store.entity.Location;
+import me.washcar.wcnc.global.definition.Regex;
+import me.washcar.wcnc.global.definition.RegexMessage;
+
+@Getter
+@AllArgsConstructor
+public class StoreRequestDto {
+
+	@Pattern(regexp = Regex.SLUG, message = RegexMessage.SLUG)
+	private String slug;
+
+	private Location location;
+
+	private String name;
+
+	private String tel;
+
+	private String description;
+
+	private String previewImage;
+
+}

--- a/src/main/java/me/washcar/wcnc/domain/store/dto/response/StoreDto.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/dto/response/StoreDto.java
@@ -1,0 +1,26 @@
+package me.washcar.wcnc.domain.store.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+import me.washcar.wcnc.domain.store.entity.Location;
+import me.washcar.wcnc.domain.store.StoreStatus;
+
+@Getter
+@Setter
+public class StoreDto {
+
+	private StoreStatus status;
+
+	private String slug;
+
+	private Location location;
+
+	private String name;
+
+	private String tel;
+
+	private String description;
+
+	private String previewImage;
+
+}

--- a/src/main/java/me/washcar/wcnc/domain/store/entity/Location.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/entity/Location.java
@@ -2,12 +2,15 @@ package me.washcar.wcnc.domain.store.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.ToString;
+import lombok.NoArgsConstructor;
 
 @Embeddable
-@ToString
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Location {
 
 	@Column(nullable = false)

--- a/src/main/java/me/washcar/wcnc/domain/store/entity/Store.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/entity/Store.java
@@ -2,6 +2,7 @@ package me.washcar.wcnc.domain.store.entity;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -69,6 +70,18 @@ public class Store extends BaseEntity {
 	@OneToMany(mappedBy = "store")
 	private final List<Reservation> reservations = new ArrayList<>();
 
+	@Builder
+	@SuppressWarnings("unused")
+	private Store(String slug, Location location, String name, String tel, String description,
+		String previewImage) {
+		this.status = StoreStatus.PENDING;
+		updateStore(slug, location, name, tel, description, previewImage);
+	}
+
+	public boolean isOwnedBy(String uuid) {
+		return Objects.equals(uuid, this.getOwner().getUuid());
+	}
+
 	public void addStoreImage(String imageUrl) {
 		StoreImage storeImage = StoreImage.builder()
 			.imageUrl(imageUrl)
@@ -81,14 +94,6 @@ public class Store extends BaseEntity {
 	public void assignOwner(Member owner) {
 		this.owner = owner;
 		owner.getStores().add(this);
-	}
-
-	@Builder
-	@SuppressWarnings("unused")
-	private Store(String slug, Location location, String name, String tel, String description,
-		String previewImage) {
-		this.status = StoreStatus.PENDING;
-		updateStore(slug, location, name, tel, description, previewImage);
 	}
 
 	public void updateStore(String slug, Location location, String name, String tel, String description,

--- a/src/main/java/me/washcar/wcnc/domain/store/entity/Store.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/entity/Store.java
@@ -13,7 +13,10 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import me.washcar.wcnc.domain.member.entity.Member;
 import me.washcar.wcnc.domain.reservation.entity.Reservation;
 import me.washcar.wcnc.domain.store.StoreStatus;
@@ -25,13 +28,14 @@ import me.washcar.wcnc.global.entity.BaseEntity;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(indexes = @Index(name = "slug_store_index", columnList = "slug"))
 public class Store extends BaseEntity {
 
 	public static final int MAX_IMAGE_NUMBER = 6;
 
 	@Column(nullable = false)
-	private StoreStatus status = StoreStatus.PENDING;
+	private StoreStatus status;
 
 	@Column(nullable = false, unique = true)
 	private String slug;
@@ -54,16 +58,16 @@ public class Store extends BaseEntity {
 	private StoreOperationHour storeOperationHour;
 
 	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "store")
-	private List<StoreImage> storeImages = new ArrayList<>();
+	private final List<StoreImage> storeImages = new ArrayList<>();
 
 	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "store")
-	private List<StoreMenu> storeMenus = new ArrayList<>();
+	private final List<StoreMenu> storeMenus = new ArrayList<>();
 
 	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "store")
-	private List<StoreOperationHoliday> storeOperationHolidays = new ArrayList<>();
+	private final List<StoreOperationHoliday> storeOperationHolidays = new ArrayList<>();
 
 	@OneToMany(mappedBy = "store")
-	private List<Reservation> reservations = new ArrayList<>();
+	private final List<Reservation> reservations = new ArrayList<>();
 
 	public void addStoreImage(String imageUrl) {
 		StoreImage storeImage = StoreImage.builder()
@@ -79,6 +83,14 @@ public class Store extends BaseEntity {
 		owner.getStores().add(this);
 	}
 
+	@Builder
+	@SuppressWarnings("unused")
+	private Store(String slug, Location location, String name, String tel, String description,
+		String previewImage) {
+		this.status = StoreStatus.PENDING;
+		updateStore(slug, location, name, tel, description, previewImage);
+	}
+
 	public void updateStore(String slug, Location location, String name, String tel, String description,
 		String previewImage) {
 		this.slug = slug;
@@ -87,6 +99,10 @@ public class Store extends BaseEntity {
 		this.tel = tel;
 		this.description = description;
 		this.previewImage = previewImage;
+	}
+
+	public void updateStatus(StoreStatus status) {
+		this.status = status;
 	}
 
 }

--- a/src/main/java/me/washcar/wcnc/domain/store/service/StoreService.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/service/StoreService.java
@@ -1,0 +1,135 @@
+package me.washcar.wcnc.domain.store.service;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import me.washcar.wcnc.domain.member.MemberRole;
+import me.washcar.wcnc.domain.member.dao.MemberRepository;
+import me.washcar.wcnc.domain.member.entity.Member;
+import me.washcar.wcnc.domain.store.StoreStatus;
+import me.washcar.wcnc.domain.store.dao.StoreRepository;
+import me.washcar.wcnc.domain.store.dto.request.StoreRequestDto;
+import me.washcar.wcnc.domain.store.dto.response.StoreDto;
+import me.washcar.wcnc.domain.store.entity.Store;
+import me.washcar.wcnc.global.error.BusinessError;
+import me.washcar.wcnc.global.error.BusinessException;
+import me.washcar.wcnc.global.utility.AuthorizationHelper;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StoreService {
+
+	private final StoreRepository storeRepository;
+
+	private final MemberRepository memberRepository;
+
+	private final AuthorizationHelper authorizationHelper;
+
+	private final ModelMapper modelMapper;
+
+	private void checkNewSlugSafety(StoreRequestDto storeRequestDto) {
+		if (storeRepository.existsBySlug(storeRequestDto.getSlug())) {
+			throw new BusinessException(BusinessError.STORE_ALREADY_EXIST);
+		}
+	}
+
+	private void checkChangeSlugSafety(String slug, StoreRequestDto storeRequestDto) {
+		if (!storeRequestDto.getSlug().equals(slug)) {
+			checkNewSlugSafety(storeRequestDto);
+		}
+	}
+
+	private void refreshStoreStatus(Store store) {
+		if (store.getStatus().equals(StoreStatus.REJECTED)) {
+			store.updateStatus(StoreStatus.PENDING);
+		}
+	}
+
+	private Store getStoreBySlugUnconditional(String slug) {
+		return storeRepository.findBySlug(slug)
+			.orElseThrow(() -> new BusinessException(BusinessError.STORE_NOT_FOUND));
+	}
+
+	public boolean amIOwner(Store store) {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		String uuid = authentication.getPrincipal().toString();
+		return uuid.equals(store.getOwner().getUuid());
+	}
+
+	public boolean isOwner(String uuid, Store store) {
+		return uuid.equals(store.getOwner().getUuid());
+	}
+
+	public void postStore(StoreRequestDto storeRequestDto, String ownerUuid) {
+		checkNewSlugSafety(storeRequestDto);
+		Store store = Store.builder()
+			.slug(storeRequestDto.getSlug())
+			.location(storeRequestDto.getLocation())
+			.name(storeRequestDto.getName())
+			.tel(storeRequestDto.getTel())
+			.description(storeRequestDto.getDescription())
+			.previewImage(storeRequestDto.getPreviewImage())
+			.build();
+		Member owner = memberRepository.findByUuid(ownerUuid)
+			.orElseThrow(() -> new BusinessException(BusinessError.MEMBER_NOT_FOUND));
+		store.assignOwner(owner);
+		storeRepository.save(store);
+	}
+
+	@Transactional(readOnly = true)
+	public Page<StoreDto> getStoreList(int page, int size) {
+		Pageable pageable = PageRequest.of(page, size);
+		Page<Store> storePage = storeRepository.findAll(pageable);
+		return storePage.map(s -> modelMapper.map(s, StoreDto.class));
+	}
+
+	@Transactional(readOnly = true)
+	public StoreDto getStoreBySlug(String slug) {
+		Store store = getStoreBySlugUnconditional(slug);
+		boolean isManager = authorizationHelper.isManager();
+		boolean isOwner = amIOwner(store);
+		boolean isOperate = store.getStatus().equals(StoreStatus.RUNNING);
+		if (isManager || isOwner || isOperate) {
+			return modelMapper.map(store, StoreDto.class);
+		} else {
+			throw new BusinessException(BusinessError.STORE_NOT_FOUND);
+		}
+	}
+
+	public StoreDto putStoreBySlug(String slug, StoreRequestDto requestDto) {
+		Store store = getStoreBySlugUnconditional(slug);
+		boolean isManager = authorizationHelper.isManager();
+		boolean isOwner = amIOwner(store);
+		if (isManager || isOwner) {
+			checkChangeSlugSafety(slug, requestDto);
+			store.updateStore(requestDto.getSlug(), requestDto.getLocation(), requestDto.getName(),
+				requestDto.getTel(), requestDto.getDescription(), requestDto.getPreviewImage());
+			refreshStoreStatus(store);
+			return modelMapper.map(store, StoreDto.class);
+		} else {
+			throw new BusinessException(BusinessError.FORBIDDEN_STORE_CHANGE);
+		}
+	}
+
+	public void deleteStoreBySlug(String slug) {
+		Store store = getStoreBySlugUnconditional(slug);
+		storeRepository.delete(store);
+	}
+
+	public void changeStoreStatusBySlug(String slug, StoreStatus storeStatus) {
+		Store store = getStoreBySlugUnconditional(slug);
+		store.updateStatus(storeStatus);
+		if (storeStatus.equals(StoreStatus.RUNNING)) {
+			store.getOwner().promote(MemberRole.ROLE_OWNER);
+		}
+	}
+
+}

--- a/src/main/java/me/washcar/wcnc/global/configuration/security/SecurityConfiguration.java
+++ b/src/main/java/me/washcar/wcnc/global/configuration/security/SecurityConfiguration.java
@@ -4,6 +4,7 @@ import static me.washcar.wcnc.domain.member.MemberRole.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -70,6 +71,25 @@ public class SecurityConfiguration {
 
 			// MemberController
 			.requestMatchers("/v2/member/**")
+			.hasAnyAuthority(ROLE_ADMIN.name(), ROLE_SUPERMAN.name())
+
+			// StoreController
+			.requestMatchers(HttpMethod.POST, "/v2/store")
+			.permitAll()
+
+			.requestMatchers(HttpMethod.GET, "/v2/store")
+			.hasAnyAuthority(ROLE_ADMIN.name(), ROLE_SUPERMAN.name())
+
+			.requestMatchers(HttpMethod.GET, "/v2/store/**")
+			.permitAll()
+
+			.requestMatchers(HttpMethod.PUT, "/v2/store/**")
+			.hasAnyAuthority(ROLE_OWNER.name(), ROLE_ADMIN.name(), ROLE_SUPERMAN.name())
+
+			.requestMatchers(HttpMethod.DELETE, "/v2/store/**")
+			.hasAnyAuthority(ROLE_SUPERMAN.name())
+
+			.requestMatchers(HttpMethod.PATCH, "/v2/store/**")
 			.hasAnyAuthority(ROLE_ADMIN.name(), ROLE_SUPERMAN.name())
 
 			// Any Request

--- a/src/main/java/me/washcar/wcnc/global/error/ApplicationError.java
+++ b/src/main/java/me/washcar/wcnc/global/error/ApplicationError.java
@@ -8,6 +8,9 @@ import lombok.Getter;
 public enum ApplicationError {
 
 	TOKEN_NOT_DELETED("인증번호 기록이 삭제되지 않았습니다."),
+	ROLE_NOT_FOUND("해당 유저가 ROLE을 가지고 있지 않습니다."),
+	ROLE_TYPE_ERROR("해당 유저가 정의되지 않은 ROLE을 가지고 있습니다."),
+	MULTIPLE_ROLE_FOUND("유저가 두 개 이상의 ROLE을 가지고 있습니다."),
 	;
 
 	private final String message;

--- a/src/main/java/me/washcar/wcnc/global/error/BusinessError.java
+++ b/src/main/java/me/washcar/wcnc/global/error/BusinessError.java
@@ -18,6 +18,10 @@ public enum BusinessError {
 	NOT_KOREAN_TELEPHONE(HttpStatus.BAD_REQUEST, "국내 전화번호로만 가입 가능합니다."),
 	OAUTH_NOT_SUPPORTED_PROVIDER(HttpStatus.BAD_REQUEST, "지원되지 않는 서비스 제공자 입니다."),
 	MEMBER_DISABLED(HttpStatus.UNAUTHORIZED, "사용자의 계정이 비활성화 되었습니다."),
+	STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "세차장을 찾을 수 없습니다."),
+	STORE_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 해당 SLUG를 가진 세차장이 존재합니다."),
+	EXCEED_STORE_IMAGE_LIMIT(HttpStatus.CONFLICT, "이미지 최대 등록 가능 횟수를 초과했습니다."),
+	FORBIDDEN_STORE_CHANGE(HttpStatus.FORBIDDEN, "해당 세차장의 정보 수정을 할 권한이 없습니다."),
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/me/washcar/wcnc/global/utility/AuthorizationHelper.java
+++ b/src/main/java/me/washcar/wcnc/global/utility/AuthorizationHelper.java
@@ -26,6 +26,11 @@ public class AuthorizationHelper {
 		return role.equals(MemberRole.ROLE_SUPERMAN);
 	}
 
+	public String getMyUuid() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		return authentication.getPrincipal().toString();
+	}
+
 	public MemberRole getMyRole() {
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 		Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();

--- a/src/main/java/me/washcar/wcnc/global/utility/AuthorizationHelper.java
+++ b/src/main/java/me/washcar/wcnc/global/utility/AuthorizationHelper.java
@@ -7,21 +7,48 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
+import lombok.RequiredArgsConstructor;
 import me.washcar.wcnc.domain.member.MemberRole;
+import me.washcar.wcnc.global.error.ApplicationError;
+import me.washcar.wcnc.global.error.ApplicationException;
 
 @Component
+@RequiredArgsConstructor
 public class AuthorizationHelper {
 
-	public boolean isAdmin() {
+	public boolean isManager() {
+		MemberRole role = getMyRole();
+		return role.equals(MemberRole.ROLE_SUPERMAN) || role.equals(MemberRole.ROLE_ADMIN);
+	}
+
+	public boolean isSuperman() {
+		MemberRole role = getMyRole();
+		return role.equals(MemberRole.ROLE_SUPERMAN);
+	}
+
+	public MemberRole getMyRole() {
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 		Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
-		for (GrantedAuthority authority : authorities) {
-			if (authority.getAuthority().equals(MemberRole.ROLE_SUPERMAN.name()) ||
-				authority.getAuthority().equals(MemberRole.ROLE_ADMIN.name())) {
-				return true;
+		if (authorities.isEmpty()) {
+			throw new ApplicationException(ApplicationError.ROLE_NOT_FOUND);
+		} else if (authorities.size() > 1) {
+			throw new ApplicationException(ApplicationError.MULTIPLE_ROLE_FOUND);
+		} else {
+			String myRole = authorities.iterator().next().getAuthority();
+			if (myRole.equals(MemberRole.ROLE_USER.name())) {
+				return MemberRole.ROLE_USER;
 			}
+			if (myRole.equals(MemberRole.ROLE_OWNER.name())) {
+				return MemberRole.ROLE_OWNER;
+			}
+			if (myRole.equals(MemberRole.ROLE_ADMIN.name())) {
+				return MemberRole.ROLE_ADMIN;
+			}
+			if (myRole.equals(MemberRole.ROLE_SUPERMAN.name())) {
+				return MemberRole.ROLE_SUPERMAN;
+			}
+			throw new ApplicationException(ApplicationError.ROLE_TYPE_ERROR);
 		}
-		return false;
 	}
 
 }

--- a/src/test/java/me/washcar/wcnc/domain/store/StoreTestHelper.java
+++ b/src/test/java/me/washcar/wcnc/domain/store/StoreTestHelper.java
@@ -1,7 +1,12 @@
 package me.washcar.wcnc.domain.store;
 
+import static me.washcar.wcnc.domain.member.MemberRole.*;
+
 import org.springframework.stereotype.Component;
 
+import me.washcar.wcnc.domain.member.MemberAuthenticationType;
+import me.washcar.wcnc.domain.member.MemberStatus;
+import me.washcar.wcnc.domain.member.entity.Member;
 import me.washcar.wcnc.domain.store.dto.request.StoreRequestDto;
 import me.washcar.wcnc.domain.store.entity.Location;
 import me.washcar.wcnc.domain.store.entity.Store;
@@ -9,9 +14,21 @@ import me.washcar.wcnc.domain.store.entity.Store;
 @Component
 public class StoreTestHelper {
 
+	private Member makeStaticOwner() {
+		return Member.builder()
+			.loginId("00WN")
+			.nickname("StaticOwner-00AA")
+			.memberRole(ROLE_OWNER)
+			.memberStatus(MemberStatus.ACTIVE)
+			.memberAuthenticationType(MemberAuthenticationType.PASSWORD)
+			.loginPassword("StaticOwner-PASSWORD")
+			.telephone("01020003000")
+			.build();
+	}
+
 	private Store makeStaticStore() {
 		Location location = new Location(30.001, 60.001, "ADD", "DETAIL", "WAY-TO");
-		return Store.builder()
+		Store store = Store.builder()
 			.slug("testslug")
 			.location(location)
 			.name("testName")
@@ -19,6 +36,8 @@ public class StoreTestHelper {
 			.description("testDescription")
 			.previewImage("https://testimage.net/storeImage")
 			.build();
+		store.assignOwner(makeStaticOwner());
+		return store;
 	}
 
 	public Store makeStaticPendingStore() {

--- a/src/test/java/me/washcar/wcnc/domain/store/StoreTestHelper.java
+++ b/src/test/java/me/washcar/wcnc/domain/store/StoreTestHelper.java
@@ -1,0 +1,53 @@
+package me.washcar.wcnc.domain.store;
+
+import org.springframework.stereotype.Component;
+
+import me.washcar.wcnc.domain.store.dto.request.StoreRequestDto;
+import me.washcar.wcnc.domain.store.entity.Location;
+import me.washcar.wcnc.domain.store.entity.Store;
+
+@Component
+public class StoreTestHelper {
+
+	private Store makeStaticStore() {
+		Location location = new Location(30.001, 60.001, "ADD", "DETAIL", "WAY-TO");
+		return Store.builder()
+			.slug("testslug")
+			.location(location)
+			.name("testName")
+			.tel("010-2341-2312")
+			.description("testDescription")
+			.previewImage("https://testimage.net/storeImage")
+			.build();
+	}
+
+	public Store makeStaticPendingStore() {
+		Store store = makeStaticStore();
+		store.updateStatus(StoreStatus.PENDING);
+		return store;
+	}
+
+	public Store makeStaticRejectedStore() {
+		Store store = makeStaticStore();
+		store.updateStatus(StoreStatus.REJECTED);
+		return store;
+	}
+
+	public Store makeStaticRunningStore() {
+		Store store = makeStaticStore();
+		store.updateStatus(StoreStatus.RUNNING);
+		return store;
+	}
+
+	public Store makeStaticClosedStore() {
+		Store store = makeStaticStore();
+		store.updateStatus(StoreStatus.CLOSED);
+		return store;
+	}
+
+	public StoreRequestDto makeStaticStoreRequestDto() {
+		Location location = new Location(35.001, 65.001, "QDD", "DETAIL", "WAY-TO");
+		return new StoreRequestDto("testslug", location, "testname2", "010-2341-2312", "testDescription",
+			"https://testimage.net/storeImage");
+	}
+}

--- a/src/test/java/me/washcar/wcnc/domain/store/dao/StoreRepositoryTest.java
+++ b/src/test/java/me/washcar/wcnc/domain/store/dao/StoreRepositoryTest.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
+import me.washcar.wcnc.domain.member.dao.MemberRepository;
 import me.washcar.wcnc.domain.store.StoreTestHelper;
 import me.washcar.wcnc.domain.store.entity.Store;
 
@@ -23,6 +24,9 @@ class StoreRepositoryTest {
 
 	@Autowired
 	private StoreRepository storeRepository;
+
+	@Autowired
+	private MemberRepository memberRepository;
 
 	@Autowired
 	private StoreTestHelper storeTestHelper;
@@ -36,6 +40,7 @@ class StoreRepositoryTest {
 		void should_success_when_singleStore() {
 			//given
 			Store store = storeTestHelper.makeStaticRunningStore();
+			memberRepository.save(store.getOwner());
 			storeRepository.save(store);
 			int page = 0;
 			int size = 10;
@@ -89,6 +94,7 @@ class StoreRepositoryTest {
 		void should_success_when_storeExist() {
 			//given
 			Store store = storeTestHelper.makeStaticRunningStore();
+			memberRepository.save(store.getOwner());
 			storeRepository.save(store);
 
 			//when

--- a/src/test/java/me/washcar/wcnc/domain/store/dao/StoreRepositoryTest.java
+++ b/src/test/java/me/washcar/wcnc/domain/store/dao/StoreRepositoryTest.java
@@ -1,0 +1,134 @@
+package me.washcar.wcnc.domain.store.dao;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+import me.washcar.wcnc.domain.store.StoreTestHelper;
+import me.washcar.wcnc.domain.store.entity.Store;
+
+@SpringBootTest
+@Transactional
+class StoreRepositoryTest {
+
+	@Autowired
+	private StoreRepository storeRepository;
+
+	@Autowired
+	private StoreTestHelper storeTestHelper;
+
+	@Nested
+	@DisplayName("세차장 목록 페이징")
+	class storePage {
+
+		@Test
+		@DisplayName("세차장이 한 곳인 경우 세차장 조회에 성공한다")
+		void should_success_when_singleStore() {
+			//given
+			Store store = storeTestHelper.makeStaticRunningStore();
+			storeRepository.save(store);
+			int page = 0;
+			int size = 10;
+
+			//when
+			Pageable pageable = PageRequest.of(page, size);
+			Page<Store> resultPage = storeRepository.findAll(pageable);
+
+			//then
+			assertThat(resultPage.getPageable()).isEqualTo(pageable);
+			assertThat(resultPage.getTotalElements()).isEqualTo(1L);
+			assertThat(resultPage.getTotalPages()).isEqualTo(1L);
+			assertThat(resultPage.getNumber()).isEqualTo(page);
+			assertThat(resultPage.getSize()).isEqualTo(size);
+			assertThat(resultPage.hasNext()).isFalse();
+			assertThat(resultPage.isFirst()).isTrue();
+
+			assertThat(resultPage.get().findFirst().isPresent()).isTrue();
+			assertThat(resultPage.get().findFirst().get()).isEqualTo(store);
+			assertThat(resultPage.get().findFirst().get().getSlug()).isEqualTo(store.getSlug());
+		}
+
+		@Test
+		@DisplayName("세차장이 없는 경우에도 세차장 조회에 성공한다")
+		void should_success_when_zeroStore() {
+			//given
+			int page = 0;
+			int size = 5;
+
+			//when
+			Pageable pageable = PageRequest.of(page, size);
+			Page<Store> resultPage = storeRepository.findAll(pageable);
+
+			//then
+			assertThat(resultPage.getPageable()).isEqualTo(pageable);
+			assertThat(resultPage.getTotalElements()).isEqualTo(0L);
+			assertThat(resultPage.getTotalPages()).isEqualTo(0L);
+			assertThat(resultPage.getNumber()).isEqualTo(page);
+			assertThat(resultPage.getSize()).isEqualTo(size);
+			assertThat(resultPage.hasNext()).isFalse();
+			assertThat(resultPage.isFirst()).isTrue();
+		}
+	}
+
+	@Nested
+	@DisplayName("세차장 SLUG 접근")
+	class storeSlug {
+
+		@Test
+		@DisplayName("세차장이 존재하는 경우 세차장 조회에 성공한다")
+		void should_success_when_storeExist() {
+			//given
+			Store store = storeTestHelper.makeStaticRunningStore();
+			storeRepository.save(store);
+
+			//when
+			Optional<Store> result = storeRepository.findBySlug(store.getSlug());
+
+			//then
+			assertThat(result).isPresent();
+			assertThat(result.get().getSlug()).isEqualTo(store.getSlug());
+			assertThat(result.get().getName()).isEqualTo(store.getName());
+		}
+
+		@Test
+		@DisplayName("세차장이 존재하지 않는 경우 세차장 조회에 실패한다")
+		void should_fail_when_storeNotExist() {
+			//given
+			//INTENDED-BLANK
+
+			//when
+			Optional<Store> result = storeRepository.findBySlug("badStoreSlug");
+
+			//then
+			assertThat(result).isEmpty();
+		}
+
+		@Test
+		@DisplayName("잘못된 SLUG 양식인 경우 멤버 조회에 실패한다")
+		void should_fail_when_wrongSlugFormat() {
+			//given
+			//INTENDED-BLANK
+
+			//when
+			Optional<Store> resultA = storeRepository.findBySlug("");
+			Optional<Store> resultB = storeRepository.findBySlug(null);
+			Optional<Store> resultC = storeRepository.findBySlug("X");
+
+			//then
+			assertThat(resultA).isEmpty();
+			assertThat(resultB).isEmpty();
+			assertThat(resultC).isEmpty();
+		}
+	}
+
+}

--- a/src/test/java/me/washcar/wcnc/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/me/washcar/wcnc/domain/store/service/StoreServiceTest.java
@@ -21,10 +21,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import me.washcar.wcnc.domain.member.MemberRole;
 import me.washcar.wcnc.domain.member.dao.MemberRepository;
+import me.washcar.wcnc.domain.store.StoreStatus;
 import me.washcar.wcnc.domain.store.StoreTestHelper;
 import me.washcar.wcnc.domain.store.dao.StoreRepository;
 import me.washcar.wcnc.domain.store.dto.request.StoreRequestDto;
+import me.washcar.wcnc.domain.store.dto.response.StoreDto;
 import me.washcar.wcnc.domain.store.entity.Store;
 import me.washcar.wcnc.global.error.BusinessException;
 import me.washcar.wcnc.global.utility.AuthorizationHelper;
@@ -41,9 +44,6 @@ class StoreServiceTest {
 	@Mock
 	private AuthorizationHelper authorizationHelper;
 
-	@Mock
-	private ModelMapper modelMapper;
-
 	private static StoreTestHelper storeTestHelper;
 
 	private static StoreService storeService;
@@ -55,7 +55,7 @@ class StoreServiceTest {
 
 	@BeforeEach
 	void beforeEach() {
-		storeService = new StoreService(storeRepository, memberRepository, authorizationHelper, modelMapper);
+		storeService = new StoreService(storeRepository, memberRepository, authorizationHelper, new ModelMapper());
 	}
 
 	@Nested
@@ -112,19 +112,18 @@ class StoreServiceTest {
 		void should_userSuccessToGetStore_when_storeIsRunning() {
 			//given
 			Store store = storeTestHelper.makeStaticRunningStore();
-			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(store));
+			Store spyStore = Mockito.spy(store);
+			when(spyStore.isOwnedBy(any())).thenReturn(false);
+			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(spyStore));
 			given(authorizationHelper.isManager()).willReturn(false);
-			StoreService spyStoreService = Mockito.spy(storeService);
-			doReturn(false).when(spyStoreService).amIOwner(any());
 
 			//when
-			spyStoreService.getStoreBySlug(store.getSlug());
+			StoreDto result = storeService.getStoreBySlug(store.getSlug());
 
 			//then
-			ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
-			verify(storeRepository).findBySlug(stringArgumentCaptor.capture());
-			String capturedString = stringArgumentCaptor.getValue();
-			assertThat(capturedString).isEqualTo(store.getSlug());
+			assertThat(result.getSlug()).isEqualTo(store.getSlug());
+			assertThat(result.getName()).isEqualTo(store.getName());
+			assertThat(result.getLocation().getLongitude()).isEqualTo(store.getLocation().getLongitude());
 		}
 
 		@Test
@@ -132,13 +131,13 @@ class StoreServiceTest {
 		void should_userFailsToGetStore_when_storeIsClosed() {
 			//given
 			Store store = storeTestHelper.makeStaticClosedStore();
-			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(store));
+			Store spyStore = Mockito.spy(store);
+			when(spyStore.isOwnedBy(any())).thenReturn(false);
+			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(spyStore));
 			given(authorizationHelper.isManager()).willReturn(false);
-			StoreService spyStoreService = Mockito.spy(storeService);
-			doReturn(false).when(spyStoreService).amIOwner(any());
 
 			//when & then
-			assertThatThrownBy(() -> spyStoreService.getStoreBySlug(store.getSlug()))
+			assertThatThrownBy(() -> storeService.getStoreBySlug(store.getSlug()))
 				.isInstanceOf(BusinessException.class);
 		}
 
@@ -147,13 +146,13 @@ class StoreServiceTest {
 		void should_userFailsToGetStore_when_storeIsPending() {
 			//given
 			Store store = storeTestHelper.makeStaticPendingStore();
-			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(store));
+			Store spyStore = Mockito.spy(store);
+			when(spyStore.isOwnedBy(any())).thenReturn(false);
+			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(spyStore));
 			given(authorizationHelper.isManager()).willReturn(false);
-			StoreService spyStoreService = Mockito.spy(storeService);
-			doReturn(false).when(spyStoreService).amIOwner(any());
 
 			//when & then
-			assertThatThrownBy(() -> spyStoreService.getStoreBySlug(store.getSlug()))
+			assertThatThrownBy(() -> storeService.getStoreBySlug(store.getSlug()))
 				.isInstanceOf(BusinessException.class);
 		}
 
@@ -162,13 +161,13 @@ class StoreServiceTest {
 		void should_userFailsToGetStore_when_storeIsRejected() {
 			//given
 			Store store = storeTestHelper.makeStaticRejectedStore();
-			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(store));
+			Store spyStore = Mockito.spy(store);
+			when(spyStore.isOwnedBy(any())).thenReturn(false);
+			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(spyStore));
 			given(authorizationHelper.isManager()).willReturn(false);
-			StoreService spyStoreService = Mockito.spy(storeService);
-			doReturn(false).when(spyStoreService).amIOwner(any());
 
 			//when & then
-			assertThatThrownBy(() -> spyStoreService.getStoreBySlug(store.getSlug()))
+			assertThatThrownBy(() -> storeService.getStoreBySlug(store.getSlug()))
 				.isInstanceOf(BusinessException.class);
 		}
 
@@ -177,59 +176,56 @@ class StoreServiceTest {
 		void should_managerSuccessToGetStore_when_storeIsRunning() {
 			//given
 			Store store = storeTestHelper.makeStaticRunningStore();
-			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(store));
+			Store spyStore = Mockito.spy(store);
+			when(spyStore.isOwnedBy(any())).thenReturn(false);
+			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(spyStore));
 			given(authorizationHelper.isManager()).willReturn(true);
-			StoreService spyStoreService = Mockito.spy(storeService);
-			doReturn(false).when(spyStoreService).amIOwner(any());
 
 			//when
-			spyStoreService.getStoreBySlug(store.getSlug());
+			StoreDto result = storeService.getStoreBySlug(store.getSlug());
 
 			//then
-			ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
-			verify(storeRepository).findBySlug(stringArgumentCaptor.capture());
-			String capturedString = stringArgumentCaptor.getValue();
-			assertThat(capturedString).isEqualTo(store.getSlug());
+			assertThat(result.getSlug()).isEqualTo(store.getSlug());
+			assertThat(result.getName()).isEqualTo(store.getName());
+			assertThat(result.getLocation().getLongitude()).isEqualTo(store.getLocation().getLongitude());
 		}
 
 		@Test
 		@DisplayName("관리자는 세차장이 운영중이 아닌 경우에도 세차장 가져오기에 성공한다")
 		void should_managerSuccessToGetStore_when_storeIsNotRunning() {
 			//given
-			Store store = storeTestHelper.makeStaticPendingStore();
-			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(store));
+			Store store = storeTestHelper.makeStaticClosedStore();
+			Store spyStore = Mockito.spy(store);
+			when(spyStore.isOwnedBy(any())).thenReturn(false);
+			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(spyStore));
 			given(authorizationHelper.isManager()).willReturn(true);
-			StoreService spyStoreService = Mockito.spy(storeService);
-			doReturn(false).when(spyStoreService).amIOwner(any());
 
 			//when
-			spyStoreService.getStoreBySlug(store.getSlug());
+			StoreDto result = storeService.getStoreBySlug(store.getSlug());
 
 			//then
-			ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
-			verify(storeRepository).findBySlug(stringArgumentCaptor.capture());
-			String capturedString = stringArgumentCaptor.getValue();
-			assertThat(capturedString).isEqualTo(store.getSlug());
+			assertThat(result.getSlug()).isEqualTo(store.getSlug());
+			assertThat(result.getName()).isEqualTo(store.getName());
+			assertThat(result.getLocation().getLongitude()).isEqualTo(store.getLocation().getLongitude());
 		}
 
 		@Test
 		@DisplayName("세차장 주인은 내 세차장이 운영중이 아닌 경우에도 세차장 가져오기에 성공한다")
 		void should_ownerSuccessToGetStore_when_myStoreIsNotRunning() {
 			//given
-			Store store = storeTestHelper.makeStaticPendingStore();
-			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(store));
+			Store store = storeTestHelper.makeStaticClosedStore();
+			Store spyStore = Mockito.spy(store);
+			when(spyStore.isOwnedBy(any())).thenReturn(true);
+			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(spyStore));
 			given(authorizationHelper.isManager()).willReturn(false);
-			StoreService spyStoreService = Mockito.spy(storeService);
-			doReturn(true).when(spyStoreService).amIOwner(any());
 
 			//when
-			spyStoreService.getStoreBySlug(store.getSlug());
+			StoreDto result = storeService.getStoreBySlug(store.getSlug());
 
 			//then
-			ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
-			verify(storeRepository).findBySlug(stringArgumentCaptor.capture());
-			String capturedString = stringArgumentCaptor.getValue();
-			assertThat(capturedString).isEqualTo(store.getSlug());
+			assertThat(result.getSlug()).isEqualTo(store.getSlug());
+			assertThat(result.getName()).isEqualTo(store.getName());
+			assertThat(result.getLocation().getLongitude()).isEqualTo(store.getLocation().getLongitude());
 		}
 
 	}
@@ -242,15 +238,15 @@ class StoreServiceTest {
 		@DisplayName("일반 유저인 경우 세차장 정보 수정에 실패한다")
 		void should_failsToPutStore_when_iAmUser() {
 			//given
-			Store store = storeTestHelper.makeStaticRunningStore();
 			StoreRequestDto storeRequestDto = storeTestHelper.makeStaticStoreRequestDto();
-			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(store));
+			Store store = storeTestHelper.makeStaticClosedStore();
+			Store spyStore = Mockito.spy(store);
+			when(spyStore.isOwnedBy(any())).thenReturn(false);
+			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(spyStore));
 			given(authorizationHelper.isManager()).willReturn(false);
-			StoreService spyStoreService = Mockito.spy(storeService);
-			doReturn(false).when(spyStoreService).amIOwner(any());
 
 			//when & then
-			assertThatThrownBy(() -> spyStoreService.putStoreBySlug(store.getSlug(), storeRequestDto))
+			assertThatThrownBy(() -> storeService.putStoreBySlug(store.getSlug(), storeRequestDto))
 				.isInstanceOf(BusinessException.class);
 		}
 
@@ -258,48 +254,40 @@ class StoreServiceTest {
 		@DisplayName("세차장 주인인 경우 세차장 정보 수정에 성공한다")
 		void should_successToPutStore_when_iAmOwner() {
 			//given
-			Store store = storeTestHelper.makeStaticRunningStore();
 			StoreRequestDto storeRequestDto = storeTestHelper.makeStaticStoreRequestDto();
-			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(store));
+			Store store = storeTestHelper.makeStaticClosedStore();
+			Store spyStore = Mockito.spy(store);
+			when(spyStore.isOwnedBy(any())).thenReturn(true);
+			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(spyStore));
 			given(authorizationHelper.isManager()).willReturn(false);
-			StoreService spyStoreService = Mockito.spy(storeService);
-			doReturn(true).when(spyStoreService).amIOwner(any());
 
 			//when
-			spyStoreService.putStoreBySlug(store.getSlug(), storeRequestDto);
+			StoreDto result = storeService.putStoreBySlug(store.getSlug(), storeRequestDto);
 
 			//then
-			ArgumentCaptor<Store> storeArgumentCaptor = ArgumentCaptor.forClass(Store.class);
-			verify(modelMapper).map(storeArgumentCaptor.capture(), any(Class.class));
-			Store capturedStore = storeArgumentCaptor.getValue();
-			assertThat(capturedStore.getName()).isEqualTo(storeRequestDto.getName());
-			assertThat(capturedStore.getSlug()).isEqualTo(storeRequestDto.getSlug());
-			assertThat(capturedStore.getLocation().getLongitude()).isEqualTo(
-				storeRequestDto.getLocation().getLongitude());
+			assertThat(result.getSlug()).isEqualTo(storeRequestDto.getSlug());
+			assertThat(result.getName()).isEqualTo(storeRequestDto.getName());
+			assertThat(result.getLocation().getLongitude()).isEqualTo(storeRequestDto.getLocation().getLongitude());
 		}
 
 		@Test
 		@DisplayName("관리자인 경우 세차장 정보 수정에 성공한다")
 		void should_successToPutStore_when_iAmManager() {
 			//given
-			Store store = storeTestHelper.makeStaticRunningStore();
 			StoreRequestDto storeRequestDto = storeTestHelper.makeStaticStoreRequestDto();
-			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(store));
+			Store store = storeTestHelper.makeStaticClosedStore();
+			Store spyStore = Mockito.spy(store);
+			when(spyStore.isOwnedBy(any())).thenReturn(false);
+			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(spyStore));
 			given(authorizationHelper.isManager()).willReturn(true);
-			StoreService spyStoreService = Mockito.spy(storeService);
-			doReturn(false).when(spyStoreService).amIOwner(any());
 
 			//when
-			spyStoreService.putStoreBySlug(store.getSlug(), storeRequestDto);
+			StoreDto result = storeService.putStoreBySlug(store.getSlug(), storeRequestDto);
 
 			//then
-			ArgumentCaptor<Store> storeArgumentCaptor = ArgumentCaptor.forClass(Store.class);
-			verify(modelMapper).map(storeArgumentCaptor.capture(), any(Class.class));
-			Store capturedStore = storeArgumentCaptor.getValue();
-			assertThat(capturedStore.getName()).isEqualTo(storeRequestDto.getName());
-			assertThat(capturedStore.getSlug()).isEqualTo(storeRequestDto.getSlug());
-			assertThat(capturedStore.getLocation().getLongitude()).isEqualTo(
-				storeRequestDto.getLocation().getLongitude());
+			assertThat(result.getSlug()).isEqualTo(storeRequestDto.getSlug());
+			assertThat(result.getName()).isEqualTo(storeRequestDto.getName());
+			assertThat(result.getLocation().getLongitude()).isEqualTo(storeRequestDto.getLocation().getLongitude());
 		}
 	}
 
@@ -345,8 +333,82 @@ class StoreServiceTest {
 
 	@Nested
 	@DisplayName("세차장 상태 변경하기")
-	@Disabled
 	class changeStoreStatusBySlug {
+
+		@Test
+		@DisplayName("USER의 세차장이 승인되는 경우 세차장 주인의 권한이 OWNER로 변경된다")
+		void should_userBecomeOwner_when_storeBecomeRunning() {
+			//given
+			Store store = storeTestHelper.makeStaticClosedStore();
+			store.getOwner().demote(MemberRole.ROLE_USER);
+			given(storeRepository.findBySlug(anyString())).willReturn(Optional.of(store));
+
+			//when
+			storeService.changeStoreStatusBySlug(store.getSlug(), StoreStatus.RUNNING);
+
+			//then
+			assertThat(store.getStatus()).isEqualTo(StoreStatus.RUNNING);
+			assertThat(store.getOwner().getMemberRole()).isEqualTo(MemberRole.ROLE_OWNER);
+		}
+
+		@Test
+		@DisplayName("OWNER의 세차장이 승인되는 경우 세차장 주인의 권한이 OWNER로 유지된다")
+		void should_ownerStaysOwner_when_storeBecomeRunning() {
+			//given
+			Store store = storeTestHelper.makeStaticClosedStore();
+			given(storeRepository.findBySlug(anyString())).willReturn(Optional.of(store));
+
+			//when
+			storeService.changeStoreStatusBySlug(store.getSlug(), StoreStatus.RUNNING);
+
+			//then
+			assertThat(store.getStatus()).isEqualTo(StoreStatus.RUNNING);
+			assertThat(store.getOwner().getMemberRole()).isEqualTo(MemberRole.ROLE_OWNER);
+		}
+
+		@Test
+		@DisplayName("ADMIN의 세차장이 승인되는 경우 세차장 주인의 권한이 ADMIN으로 유지된다")
+		void should_adminStaysAdmin_when_storeBecomeRunning() {
+			//given
+			Store store = storeTestHelper.makeStaticClosedStore();
+			store.getOwner().promote(MemberRole.ROLE_ADMIN);
+			given(storeRepository.findBySlug(anyString())).willReturn(Optional.of(store));
+
+			//when
+			storeService.changeStoreStatusBySlug(store.getSlug(), StoreStatus.RUNNING);
+
+			//then
+			assertThat(store.getStatus()).isEqualTo(StoreStatus.RUNNING);
+			assertThat(store.getOwner().getMemberRole()).isEqualTo(MemberRole.ROLE_ADMIN);
+		}
+
+		@Test
+		@DisplayName("SUPERMAN의 세차장이 승인되는 경우 세차장 주인의 권한이 SUPERMAN으로 유지된다")
+		void should_supermanStaysSuperman_when_storeBecomeRunning() {
+			//given
+			Store store = storeTestHelper.makeStaticClosedStore();
+			store.getOwner().promote(MemberRole.ROLE_SUPERMAN);
+			given(storeRepository.findBySlug(anyString())).willReturn(Optional.of(store));
+
+			//when
+			storeService.changeStoreStatusBySlug(store.getSlug(), StoreStatus.RUNNING);
+
+			//then
+			assertThat(store.getStatus()).isEqualTo(StoreStatus.RUNNING);
+			assertThat(store.getOwner().getMemberRole()).isEqualTo(MemberRole.ROLE_SUPERMAN);
+		}
+
+		@Test
+		@DisplayName("세차장이 존재하지 않는 경우 에러를 반환한다")
+		void should_errorChangeStore_when_storeNotExist() {
+			//given
+			given(storeRepository.findBySlug(anyString())).willReturn(Optional.empty());
+
+			//when & then
+			assertThatThrownBy(() -> storeService.changeStoreStatusBySlug("badStoreSlug", StoreStatus.RUNNING))
+				.isInstanceOf(BusinessException.class);
+		}
+
 	}
 
 }

--- a/src/test/java/me/washcar/wcnc/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/me/washcar/wcnc/domain/store/service/StoreServiceTest.java
@@ -1,0 +1,352 @@
+package me.washcar.wcnc.domain.store.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import me.washcar.wcnc.domain.member.dao.MemberRepository;
+import me.washcar.wcnc.domain.store.StoreTestHelper;
+import me.washcar.wcnc.domain.store.dao.StoreRepository;
+import me.washcar.wcnc.domain.store.dto.request.StoreRequestDto;
+import me.washcar.wcnc.domain.store.entity.Store;
+import me.washcar.wcnc.global.error.BusinessException;
+import me.washcar.wcnc.global.utility.AuthorizationHelper;
+
+@ExtendWith(MockitoExtension.class)
+class StoreServiceTest {
+
+	@Mock
+	private StoreRepository storeRepository;
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Mock
+	private AuthorizationHelper authorizationHelper;
+
+	@Mock
+	private ModelMapper modelMapper;
+
+	private static StoreTestHelper storeTestHelper;
+
+	private static StoreService storeService;
+
+	@BeforeAll
+	static void beforeAll() {
+		storeTestHelper = new StoreTestHelper();
+	}
+
+	@BeforeEach
+	void beforeEach() {
+		storeService = new StoreService(storeRepository, memberRepository, authorizationHelper, modelMapper);
+	}
+
+	@Nested
+	@DisplayName("세차장 생성 요청하기")
+	@Disabled
+	class postStore {
+	}
+
+	@Nested
+	@DisplayName("세차장 목록 가져오기")
+	class getStoreList {
+
+		@Test
+		@DisplayName("page와 size가 정상 범위인 경우 Pageable역시 동일한 값을 가진다")
+		void should_pageableIsCorrect_when_pageAndSizesAreInCorrectRange() {
+			//given
+			int page = 2;
+			int size = 10;
+			Pageable pageable = PageRequest.of(page, size);
+			@SuppressWarnings("unchecked")
+			Page<Store> storePage = Mockito.mock(Page.class);
+			when(storeRepository.findAll(pageable)).thenReturn(storePage);
+
+			//when
+			storeService.getStoreList(page, size);
+
+			//then
+			ArgumentCaptor<Pageable> pageableArgumentCaptor = ArgumentCaptor.forClass(Pageable.class);
+			verify(storeRepository).findAll(pageableArgumentCaptor.capture());
+			Pageable capturedPageable = pageableArgumentCaptor.getValue();
+			assertThat(capturedPageable.getPageNumber()).isEqualTo(page);
+			assertThat(capturedPageable.getPageSize()).isEqualTo(size);
+		}
+
+	}
+
+	@Nested
+	@DisplayName("SLUG로 세차장 가져오기")
+	class getStoreBySlug {
+
+		@Test
+		@DisplayName("세차장이 존재하지 않는 경우 세차장 가져오기에 실패한다")
+		void should_failToGetStore_when_storeNotExist() {
+			//given
+			given(storeRepository.findBySlug(anyString())).willReturn(Optional.empty());
+
+			//when & then
+			assertThatThrownBy(() -> storeService.getStoreBySlug("badStoreSlug"))
+				.isInstanceOf(BusinessException.class);
+		}
+
+		@Test
+		@DisplayName("일반 유저는 세차장이 운영중인 경우 세차장 가져오기에 성공한다")
+		void should_userSuccessToGetStore_when_storeIsRunning() {
+			//given
+			Store store = storeTestHelper.makeStaticRunningStore();
+			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(store));
+			given(authorizationHelper.isManager()).willReturn(false);
+			StoreService spyStoreService = Mockito.spy(storeService);
+			doReturn(false).when(spyStoreService).amIOwner(any());
+
+			//when
+			spyStoreService.getStoreBySlug(store.getSlug());
+
+			//then
+			ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
+			verify(storeRepository).findBySlug(stringArgumentCaptor.capture());
+			String capturedString = stringArgumentCaptor.getValue();
+			assertThat(capturedString).isEqualTo(store.getSlug());
+		}
+
+		@Test
+		@DisplayName("일반 유저는 세차장이 휴점중인 경우 세차장 가져오기에 실패한다")
+		void should_userFailsToGetStore_when_storeIsClosed() {
+			//given
+			Store store = storeTestHelper.makeStaticClosedStore();
+			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(store));
+			given(authorizationHelper.isManager()).willReturn(false);
+			StoreService spyStoreService = Mockito.spy(storeService);
+			doReturn(false).when(spyStoreService).amIOwner(any());
+
+			//when & then
+			assertThatThrownBy(() -> spyStoreService.getStoreBySlug(store.getSlug()))
+				.isInstanceOf(BusinessException.class);
+		}
+
+		@Test
+		@DisplayName("일반 유저는 세차장이 대기중인 경우 세차장 가져오기에 실패한다")
+		void should_userFailsToGetStore_when_storeIsPending() {
+			//given
+			Store store = storeTestHelper.makeStaticPendingStore();
+			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(store));
+			given(authorizationHelper.isManager()).willReturn(false);
+			StoreService spyStoreService = Mockito.spy(storeService);
+			doReturn(false).when(spyStoreService).amIOwner(any());
+
+			//when & then
+			assertThatThrownBy(() -> spyStoreService.getStoreBySlug(store.getSlug()))
+				.isInstanceOf(BusinessException.class);
+		}
+
+		@Test
+		@DisplayName("일반 유저는 세차장이 거부 상태인 경우 세차장 가져오기에 실패한다")
+		void should_userFailsToGetStore_when_storeIsRejected() {
+			//given
+			Store store = storeTestHelper.makeStaticRejectedStore();
+			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(store));
+			given(authorizationHelper.isManager()).willReturn(false);
+			StoreService spyStoreService = Mockito.spy(storeService);
+			doReturn(false).when(spyStoreService).amIOwner(any());
+
+			//when & then
+			assertThatThrownBy(() -> spyStoreService.getStoreBySlug(store.getSlug()))
+				.isInstanceOf(BusinessException.class);
+		}
+
+		@Test
+		@DisplayName("관리자는 세차장이 운영중인 경우 세차장 가져오기에 성공한다")
+		void should_managerSuccessToGetStore_when_storeIsRunning() {
+			//given
+			Store store = storeTestHelper.makeStaticRunningStore();
+			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(store));
+			given(authorizationHelper.isManager()).willReturn(true);
+			StoreService spyStoreService = Mockito.spy(storeService);
+			doReturn(false).when(spyStoreService).amIOwner(any());
+
+			//when
+			spyStoreService.getStoreBySlug(store.getSlug());
+
+			//then
+			ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
+			verify(storeRepository).findBySlug(stringArgumentCaptor.capture());
+			String capturedString = stringArgumentCaptor.getValue();
+			assertThat(capturedString).isEqualTo(store.getSlug());
+		}
+
+		@Test
+		@DisplayName("관리자는 세차장이 운영중이 아닌 경우에도 세차장 가져오기에 성공한다")
+		void should_managerSuccessToGetStore_when_storeIsNotRunning() {
+			//given
+			Store store = storeTestHelper.makeStaticPendingStore();
+			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(store));
+			given(authorizationHelper.isManager()).willReturn(true);
+			StoreService spyStoreService = Mockito.spy(storeService);
+			doReturn(false).when(spyStoreService).amIOwner(any());
+
+			//when
+			spyStoreService.getStoreBySlug(store.getSlug());
+
+			//then
+			ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
+			verify(storeRepository).findBySlug(stringArgumentCaptor.capture());
+			String capturedString = stringArgumentCaptor.getValue();
+			assertThat(capturedString).isEqualTo(store.getSlug());
+		}
+
+		@Test
+		@DisplayName("세차장 주인은 내 세차장이 운영중이 아닌 경우에도 세차장 가져오기에 성공한다")
+		void should_ownerSuccessToGetStore_when_myStoreIsNotRunning() {
+			//given
+			Store store = storeTestHelper.makeStaticPendingStore();
+			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(store));
+			given(authorizationHelper.isManager()).willReturn(false);
+			StoreService spyStoreService = Mockito.spy(storeService);
+			doReturn(true).when(spyStoreService).amIOwner(any());
+
+			//when
+			spyStoreService.getStoreBySlug(store.getSlug());
+
+			//then
+			ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
+			verify(storeRepository).findBySlug(stringArgumentCaptor.capture());
+			String capturedString = stringArgumentCaptor.getValue();
+			assertThat(capturedString).isEqualTo(store.getSlug());
+		}
+
+	}
+
+	@Nested
+	@DisplayName("세차장 정보 수정하기")
+	class putStoreBySlug {
+
+		@Test
+		@DisplayName("일반 유저인 경우 세차장 정보 수정에 실패한다")
+		void should_failsToPutStore_when_iAmUser() {
+			//given
+			Store store = storeTestHelper.makeStaticRunningStore();
+			StoreRequestDto storeRequestDto = storeTestHelper.makeStaticStoreRequestDto();
+			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(store));
+			given(authorizationHelper.isManager()).willReturn(false);
+			StoreService spyStoreService = Mockito.spy(storeService);
+			doReturn(false).when(spyStoreService).amIOwner(any());
+
+			//when & then
+			assertThatThrownBy(() -> spyStoreService.putStoreBySlug(store.getSlug(), storeRequestDto))
+				.isInstanceOf(BusinessException.class);
+		}
+
+		@Test
+		@DisplayName("세차장 주인인 경우 세차장 정보 수정에 성공한다")
+		void should_successToPutStore_when_iAmOwner() {
+			//given
+			Store store = storeTestHelper.makeStaticRunningStore();
+			StoreRequestDto storeRequestDto = storeTestHelper.makeStaticStoreRequestDto();
+			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(store));
+			given(authorizationHelper.isManager()).willReturn(false);
+			StoreService spyStoreService = Mockito.spy(storeService);
+			doReturn(true).when(spyStoreService).amIOwner(any());
+
+			//when
+			spyStoreService.putStoreBySlug(store.getSlug(), storeRequestDto);
+
+			//then
+			ArgumentCaptor<Store> storeArgumentCaptor = ArgumentCaptor.forClass(Store.class);
+			verify(modelMapper).map(storeArgumentCaptor.capture(), any(Class.class));
+			Store capturedStore = storeArgumentCaptor.getValue();
+			assertThat(capturedStore.getName()).isEqualTo(storeRequestDto.getName());
+			assertThat(capturedStore.getSlug()).isEqualTo(storeRequestDto.getSlug());
+			assertThat(capturedStore.getLocation().getLongitude()).isEqualTo(
+				storeRequestDto.getLocation().getLongitude());
+		}
+
+		@Test
+		@DisplayName("관리자인 경우 세차장 정보 수정에 성공한다")
+		void should_successToPutStore_when_iAmManager() {
+			//given
+			Store store = storeTestHelper.makeStaticRunningStore();
+			StoreRequestDto storeRequestDto = storeTestHelper.makeStaticStoreRequestDto();
+			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(store));
+			given(authorizationHelper.isManager()).willReturn(true);
+			StoreService spyStoreService = Mockito.spy(storeService);
+			doReturn(false).when(spyStoreService).amIOwner(any());
+
+			//when
+			spyStoreService.putStoreBySlug(store.getSlug(), storeRequestDto);
+
+			//then
+			ArgumentCaptor<Store> storeArgumentCaptor = ArgumentCaptor.forClass(Store.class);
+			verify(modelMapper).map(storeArgumentCaptor.capture(), any(Class.class));
+			Store capturedStore = storeArgumentCaptor.getValue();
+			assertThat(capturedStore.getName()).isEqualTo(storeRequestDto.getName());
+			assertThat(capturedStore.getSlug()).isEqualTo(storeRequestDto.getSlug());
+			assertThat(capturedStore.getLocation().getLongitude()).isEqualTo(
+				storeRequestDto.getLocation().getLongitude());
+		}
+	}
+
+	@Nested
+	@DisplayName("세차장 삭제하기")
+	class deleteStoreBySlug {
+
+		@Test
+		@DisplayName("세차장이 존재하는 경우 세차장 삭제하기에 성공한다")
+		void should_successDeleteStore_when_storeExist() {
+			//given
+			Store store = storeTestHelper.makeStaticClosedStore();
+			given(storeRepository.findBySlug(store.getSlug())).willReturn(Optional.of(store));
+
+			//when
+			storeService.deleteStoreBySlug(store.getSlug());
+
+			//then
+			ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
+			verify(storeRepository).findBySlug(stringArgumentCaptor.capture());
+			String capturedString = stringArgumentCaptor.getValue();
+			assertThat(capturedString).isEqualTo(store.getSlug());
+
+			ArgumentCaptor<Store> storeArgumentCaptor = ArgumentCaptor.forClass(Store.class);
+			verify(storeRepository).delete(storeArgumentCaptor.capture());
+			Store capturedStore = storeArgumentCaptor.getValue();
+			assertThat(capturedStore).isEqualTo(store);
+		}
+
+		@Test
+		@DisplayName("세차장이 존재하지 않는 경우 에러를 반환한다")
+		void should_errorDeleteStore_when_storeNotExist() {
+			//given
+			given(storeRepository.findBySlug(anyString())).willReturn(Optional.empty());
+
+			//when & then
+			assertThatThrownBy(() -> storeService.deleteStoreBySlug("badStoreSlug"))
+				.isInstanceOf(BusinessException.class);
+			verify(storeRepository, never()).delete(any());
+		}
+
+	}
+
+	@Nested
+	@DisplayName("세차장 상태 변경하기")
+	@Disabled
+	class changeStoreStatusBySlug {
+	}
+
+}


### PR DESCRIPTION
## 🔥 관련 이슈

없음

## 📝 작업 상세 설명

Store 도메인의 CRUD api 및 테스트코드를 구현하였습니다.
더 빠른 속도를 위해서 service 테스트 코드에는 `@SpringBootTest` 사용을 지양하고 있습니다.

다음 API들을 구현하였습니다:

- [x] 세차장 생성 요청
- [x] 모든 세차장 조회
- [x] 해당 세차장 조회
- [x] 해당 세차장 수정
- [x] 해당 세차장 삭제 (HARD DELETE)
- [x] 세차장 승인/거부 (storeStatus 변경)

적용한 비즈니스 로직 중 까다로웠던 부분들은 다음과 같습니다:

- 해당 세차장 조회 로직은 내가 세차장의 주인이거나, 내가 관리자(manager)이거나, 세차장이 운영 중인 경우에만 조회가 되어야 합니다.
  - manager == ROLE_ADMIN || ROLE_SUPERMAN
- 세차장 승인 과정에서, 세차장의 주인인 멤버의 역할이 ROLE_OWNER가 되어야 합니다.
- 세차장 승인 과정에서, 세차장의 주인 멤버의 역할이 바뀌는 로직은 오직 권한 상승(promote)이여야 합니다.
  - 관리자가 주인인 세차장을 승인하면, 관리자는 ROLE_OWNER가 되면 안 됩니다.
  - 의도하지 않은 실수를 줄이기 위해서 member의 상태 변경을 promote()와 demote()메소드로 분리하였습니다.
  - ```JAVA
    public void promote(MemberRole memberRole) {
      if (this.memberRole.ordinal() < memberRole.ordinal()) {
        this.memberRole = memberRole;
      }
    }
    
    public void demote(MemberRole memberRole) {
      if (this.memberRole.ordinal() > memberRole.ordinal()) {
        this.memberRole = memberRole;
      }
    }
    ```

## ⭐ 리뷰 요구 사항

테스트코드의 중복 설정 및 Assertion을 최소화 할 필요가 있어 보입니다.
일부 `@Disabled` 된 테스트코드의 경우 서비스 내부에 복잡한 로직이 없어 테스트를 구현하지 않았습니다.
