### PR TITLE
fix: Repository의 페이지네이션 테스트 버그 수정 및 테스트 전용 설정파일 추가

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -26,3 +26,11 @@ front-server:
 
 cookie:
   domain: localhost
+
+aligo:
+  test-mode: Y
+
+# 모든 디버깅 로그 확인하려면 주석 해제
+#logging:
+#  level:
+#    root: debug

--- a/src/test/java/me/washcar/wcnc/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/me/washcar/wcnc/domain/member/dao/MemberRepositoryTest.java
@@ -15,9 +15,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
-import me.washcar.wcnc.domain.member.entity.Member;
 import me.washcar.wcnc.domain.member.MemberStatus;
 import me.washcar.wcnc.domain.member.MemberTestHelper;
+import me.washcar.wcnc.domain.member.entity.Member;
 
 @SpringBootTest
 @Transactional
@@ -38,6 +38,7 @@ class MemberRepositoryTest {
 		void should_success_when_singleMember() {
 			//given
 			Member member = memberTestHelper.makeStaticMember();
+			memberRepository.deleteAll();
 			memberRepository.save(member);
 			int page = 0;
 			int size = 12;
@@ -64,6 +65,7 @@ class MemberRepositoryTest {
 		@DisplayName("멤버가 없는 경우에도 멤버 조회에 성공한다")
 		void should_success_when_zeroMember() {
 			//given
+			memberRepository.deleteAll();
 			int page = 0;
 			int size = 5;
 

--- a/src/test/java/me/washcar/wcnc/domain/store/dao/StoreRepositoryTest.java
+++ b/src/test/java/me/washcar/wcnc/domain/store/dao/StoreRepositoryTest.java
@@ -41,6 +41,7 @@ class StoreRepositoryTest {
 			//given
 			Store store = storeTestHelper.makeStaticRunningStore();
 			memberRepository.save(store.getOwner());
+			storeRepository.deleteAll();
 			storeRepository.save(store);
 			int page = 0;
 			int size = 10;
@@ -67,6 +68,7 @@ class StoreRepositoryTest {
 		@DisplayName("세차장이 없는 경우에도 세차장 조회에 성공한다")
 		void should_success_when_zeroStore() {
 			//given
+			storeRepository.deleteAll();
 			int page = 0;
 			int size = 5;
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,10 +4,20 @@ server:
 spring:
   jpa:
     properties:
+      hibernate:
+        '[format_sql]': true
       jakarta:
         persistence:
           sharedCache:
             mode: ALL
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/wcnc
+    username: root
+    password: 12345678
 
   output:
     ansi:
@@ -18,11 +28,13 @@ spring:
       client:
         registration:
           kakao:
+            redirect-uri: http://localhost/v2/oauth2/code/kakao
             client-id: ENC(MwqgJCEZvLd09qmLEKACjqmpVcFTQPdCYRMOo4h7hRbAbMf28Ligudq0Be53p/+th5pwyH0tAfGqz/a0pCWOTnF+fHwUYojXl+A+y2wD5fI=)
             client-secret: ENC(sBsq9JGrIBmWM8DQjPVMHoFPxJyewCmuFb0u9r3JS8wx/rljSY0AG7TVUxC2sgeoV1C/amCCm9hTor9uscX9llOjLaUuglocooNVWF47umE=)
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
           naver:
+            redirect-uri: http://localhost/v2/oauth2/code/naver
             client-id: ENC(QoPYA0N/TrDWg7C/5U7MFzblgyjscWEhzcAK+JmkYhO1lmovvAG2Jxl4vUCXFJulq38lH6y4kc8KvPVTZ2282Q==)
             client-secret: ENC(V7Z5dxMvXtyKt1i4j20kXjHAATYqiy7PBKYSGc0En0fs2s6OKN6x++PBuVcPqt9o)
             authorization-grant-type: authorization_code
@@ -40,6 +52,7 @@ spring:
 
 cookie:
   max-age: 7776000  # 60*60*24*90, 90일
+  domain: localhost
 
 jwt:
   secret: ENC(JVwhYMrePbdtTctule63uRffzJqwJTFM6Li5iGlVYgTO65+WJB8Mm7U8OuzGy5DjRpYF+VtsaLrLYLbwJFOrRfh0GGw9P+feKwdTYnRXu0EqSsOsy/+Lnda7JZ6pF5//J2uqnouu50qbO9mSz/k4nw==)
@@ -48,6 +61,10 @@ aligo:
   user-id: ENC(k8jv+PN+JrjeTABq+4LBCjfZgJtTn5QoouIh9ijqzqD88fyvIFc6wIy7fnQvGacR)
   sender: ENC(Uxrf/79EqQl/zihPKnpNcbm1/gpL7vD1dK1wIHx42FLXNWaIf/UPASThCv+RGkQI)
   api-key: ENC(scZI8D+4/sqTYB6rDPNmWRAuvBM3Gvafk9SpcbXUPfrtn36mjKehMr6Afe/drug7991ZksvCNhiIaspzA1OwthJt6qxJTpt2iV69V962Hos=)
+  test-mode: Y
+
+front-server:
+  domain: http://localhost:3000
 
 jasypt:
   encryptor:


### PR DESCRIPTION
## 🔥 관련 이슈

없음

## 📝 작업 상세 설명

- 조회된 값의 개수를 체크하는 Assert 구문이 원인이였던, TEST DB가 비워져있지 않던 상황에서 Repository의 페이지네이션 테스트가 통과하지 않던 버그를 수정하였습니다.

- 이 과정에서 위험한 `deleteAll()` 메소드를 사용하기 때문에, production setting에서 테스트코드의 `@Transactional`이 실수로 제거되는 경우 운영 DB가 전체 삭제되는 경우를 막기 위해서 TEST코드 전용 설정파일을 추가하고, 테스트코드에서 사용할 수 있는 Datasource를 고정하였습니다.

- 일부 테스트용 설정 값의 위치를 dev 환경 설정 파일로 이동하였습니다

## ⭐ 리뷰 요구 사항

`deleteAllInBatch()` 가 더 빠르지만, JPA Cascading이 지원되지 않아 사용이 불가능했습니다. 해당 메소드 사용을 위해서 DATABASE cascade를 추가하는 것 역시 바람직하지 않다고 생각합니다. 
