### PR TITLE
Feature/store menu api

### DIFF
--- a/src/main/java/me/washcar/wcnc/domain/reservation/entity/Reservation.java
+++ b/src/main/java/me/washcar/wcnc/domain/reservation/entity/Reservation.java
@@ -13,7 +13,7 @@ import me.washcar.wcnc.domain.car.model.entity.Model;
 import me.washcar.wcnc.domain.member.entity.Member;
 import me.washcar.wcnc.domain.reservation.ReservationStatus;
 import me.washcar.wcnc.domain.store.entity.Store;
-import me.washcar.wcnc.domain.store.entity.menu.StoreMenu;
+import me.washcar.wcnc.domain.store.entity.menu.entity.StoreMenu;
 import me.washcar.wcnc.global.entity.UuidEntity;
 
 @Entity

--- a/src/main/java/me/washcar/wcnc/domain/store/entity/Store.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/entity/Store.java
@@ -22,7 +22,7 @@ import me.washcar.wcnc.domain.member.entity.Member;
 import me.washcar.wcnc.domain.reservation.entity.Reservation;
 import me.washcar.wcnc.domain.store.StoreStatus;
 import me.washcar.wcnc.domain.store.entity.image.entity.StoreImage;
-import me.washcar.wcnc.domain.store.entity.menu.StoreMenu;
+import me.washcar.wcnc.domain.store.entity.menu.entity.StoreMenu;
 import me.washcar.wcnc.domain.store.entity.operation.StoreOperationHoliday;
 import me.washcar.wcnc.domain.store.entity.operation.StoreOperationHour;
 import me.washcar.wcnc.global.entity.BaseEntity;
@@ -87,6 +87,15 @@ public class Store extends BaseEntity {
 
 	public void deleteStoreImage(StoreImage storeImage) {
 		this.storeImages.remove(storeImage);
+	}
+
+	public void addStoreMenu(StoreMenu storeMenu) {
+		this.storeMenus.add(storeMenu);
+		storeMenu.setStore(this);
+	}
+
+	public void deleteStoreMenu(StoreMenu storeMenu) {
+		this.storeMenus.remove(storeMenu);
 	}
 
 	public void assignOwner(Member owner) {

--- a/src/main/java/me/washcar/wcnc/domain/store/entity/image/dto/response/ImagesDto.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/entity/image/dto/response/ImagesDto.java
@@ -3,12 +3,14 @@ package me.washcar.wcnc.domain.store.entity.image.dto.response;
 import java.util.List;
 
 import lombok.Getter;
-import lombok.Setter;
 
-@Setter
 @Getter
 public class ImagesDto {
 
-	private List<ImageResponseDto> images;
-	
+	private final List<ImageResponseDto> images;
+
+	public ImagesDto(List<ImageResponseDto> images) {
+		this.images = images;
+	}
+
 }

--- a/src/main/java/me/washcar/wcnc/domain/store/entity/menu/controller/StoreMenuController.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/entity/menu/controller/StoreMenuController.java
@@ -1,0 +1,76 @@
+package me.washcar.wcnc.domain.store.entity.menu.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import lombok.RequiredArgsConstructor;
+import me.washcar.wcnc.domain.store.entity.menu.dto.request.MenuRequestDto;
+import me.washcar.wcnc.domain.store.entity.menu.dto.response.MenuResponseDto;
+import me.washcar.wcnc.domain.store.entity.menu.dto.response.MenusDto;
+import me.washcar.wcnc.domain.store.entity.menu.service.StoreMenuService;
+import me.washcar.wcnc.global.definition.Regex;
+import me.washcar.wcnc.global.definition.RegexMessage;
+
+@RestController
+@RequestMapping("/v2")
+@RequiredArgsConstructor
+public class StoreMenuController {
+
+	private final StoreMenuService storeMenuService;
+
+	@PostMapping("/store/{slug}/menu")
+	public ResponseEntity<Void> create(
+		@PathVariable @Pattern(regexp = Regex.SLUG, message = RegexMessage.SLUG) String slug,
+		@RequestBody @Valid MenuRequestDto requestDto) {
+		storeMenuService.create(slug, requestDto);
+		return ResponseEntity
+			.status(HttpStatus.CREATED)
+			.build();
+	}
+
+	@GetMapping("/store/{slug}/menu")
+	public ResponseEntity<MenusDto> getMenusBySlug(
+		@PathVariable @Pattern(regexp = Regex.SLUG, message = RegexMessage.SLUG) String slug) {
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(storeMenuService.getMenusBySlug(slug));
+	}
+
+	@GetMapping("/menu/{uuid}")
+	public ResponseEntity<MenuResponseDto> getMenuByUuid(
+		@PathVariable @Pattern(regexp = Regex.UUID_V4, message = RegexMessage.UUID_V4) String uuid) {
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(storeMenuService.getMenuByUuid(uuid));
+	}
+
+	@PutMapping("/menu/{uuid}")
+	public ResponseEntity<Void> putMenuByUuid(
+		@PathVariable @Pattern(regexp = Regex.UUID_V4, message = RegexMessage.UUID_V4) String uuid,
+		@RequestBody @Valid MenuRequestDto requestDto) {
+		storeMenuService.putMenuByUuid(uuid, requestDto);
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.build();
+	}
+
+	@DeleteMapping("/menu/{uuid}")
+	public ResponseEntity<Void> deleteMenuByUuid(
+		@PathVariable @Pattern(regexp = Regex.UUID_V4, message = RegexMessage.UUID_V4) String uuid) {
+		storeMenuService.deleteMenuByUuid(uuid);
+		return ResponseEntity
+			.status(HttpStatus.NO_CONTENT)
+			.build();
+	}
+
+}

--- a/src/main/java/me/washcar/wcnc/domain/store/entity/menu/dao/StoreMenuRepository.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/entity/menu/dao/StoreMenuRepository.java
@@ -1,0 +1,13 @@
+package me.washcar.wcnc.domain.store.entity.menu.dao;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.washcar.wcnc.domain.store.entity.menu.entity.StoreMenu;
+
+public interface StoreMenuRepository extends JpaRepository<StoreMenu, Long> {
+
+	Optional<StoreMenu> findByUuid(String uuid);
+
+}

--- a/src/main/java/me/washcar/wcnc/domain/store/entity/menu/dto/request/MenuRequestDto.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/entity/menu/dto/request/MenuRequestDto.java
@@ -1,10 +1,11 @@
 package me.washcar.wcnc.domain.store.entity.menu.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@SuppressWarnings("unused")
+@Builder
 public class MenuRequestDto {
 
 	@NotBlank

--- a/src/main/java/me/washcar/wcnc/domain/store/entity/menu/dto/request/MenuRequestDto.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/entity/menu/dto/request/MenuRequestDto.java
@@ -1,0 +1,20 @@
+package me.washcar.wcnc.domain.store.entity.menu.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+@SuppressWarnings("unused")
+public class MenuRequestDto {
+
+	@NotBlank
+	private int price;
+
+	@NotBlank
+	private int expectedMinute;
+
+	private String description;
+
+	private String image;
+
+}

--- a/src/main/java/me/washcar/wcnc/domain/store/entity/menu/dto/request/MenuRequestDto.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/entity/menu/dto/request/MenuRequestDto.java
@@ -9,10 +9,10 @@ import lombok.Getter;
 public class MenuRequestDto {
 
 	@NotBlank
-	private int price;
+	private Integer price;
 
 	@NotBlank
-	private int expectedMinute;
+	private Integer expectedMinute;
 
 	private String description;
 

--- a/src/main/java/me/washcar/wcnc/domain/store/entity/menu/dto/response/MenuResponseDto.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/entity/menu/dto/response/MenuResponseDto.java
@@ -7,9 +7,9 @@ import lombok.Setter;
 @Getter
 public class MenuResponseDto {
 
-	private int price;
+	private Integer price;
 
-	private int expectedMinute;
+	private Integer expectedMinute;
 
 	private String description;
 

--- a/src/main/java/me/washcar/wcnc/domain/store/entity/menu/dto/response/MenuResponseDto.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/entity/menu/dto/response/MenuResponseDto.java
@@ -1,0 +1,20 @@
+package me.washcar.wcnc.domain.store.entity.menu.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class MenuResponseDto {
+
+	private int price;
+
+	private int expectedMinute;
+
+	private String description;
+
+	private String image;
+
+	private String uuid;
+
+}

--- a/src/main/java/me/washcar/wcnc/domain/store/entity/menu/dto/response/MenusDto.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/entity/menu/dto/response/MenusDto.java
@@ -1,0 +1,16 @@
+package me.washcar.wcnc.domain.store.entity.menu.dto.response;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class MenusDto {
+
+	private final List<MenuResponseDto> menus;
+
+	public MenusDto(List<MenuResponseDto> menus) {
+		this.menus = menus;
+	}
+
+}

--- a/src/main/java/me/washcar/wcnc/domain/store/entity/menu/entity/StoreMenu.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/entity/menu/entity/StoreMenu.java
@@ -26,10 +26,10 @@ import me.washcar.wcnc.global.entity.UuidEntity;
 public class StoreMenu extends UuidEntity {
 
 	@Column(nullable = false)
-	private int price;
+	private Integer price;
 
 	@Column(nullable = false)
-	private int expectedMinute;
+	private Integer expectedMinute;
 
 	private String description;
 
@@ -42,7 +42,7 @@ public class StoreMenu extends UuidEntity {
 	@OneToMany(mappedBy = "storeMenu")
 	private final Collection<Reservation> reservations = new ArrayList<>();
 
-	public void updateMenu(int price, int expectedMinute, String description, String image) {
+	public void updateMenu(Integer price, Integer expectedMinute, String description, String image) {
 		this.price = price;
 		this.expectedMinute = expectedMinute;
 		this.description = description;
@@ -51,7 +51,7 @@ public class StoreMenu extends UuidEntity {
 
 	@Builder
 	@SuppressWarnings("unused")
-	public StoreMenu(int price, int expectedMinute, String description, String image) {
+	public StoreMenu(Integer price, Integer expectedMinute, String description, String image) {
 		this.price = price;
 		this.expectedMinute = expectedMinute;
 		this.description = description;

--- a/src/main/java/me/washcar/wcnc/domain/store/entity/menu/entity/StoreMenu.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/entity/menu/entity/StoreMenu.java
@@ -1,4 +1,4 @@
-package me.washcar.wcnc.domain.store.entity.menu;
+package me.washcar.wcnc.domain.store.entity.menu.entity;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -10,13 +10,18 @@ import jakarta.persistence.Index;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import me.washcar.wcnc.domain.reservation.entity.Reservation;
 import me.washcar.wcnc.domain.store.entity.Store;
 import me.washcar.wcnc.global.entity.UuidEntity;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(indexes = @Index(name = "uuid_store_menu_index", columnList = "uuid"))
 public class StoreMenu extends UuidEntity {
 
@@ -24,15 +29,33 @@ public class StoreMenu extends UuidEntity {
 	private int price;
 
 	@Column(nullable = false)
-	private Long expectedMinute;
+	private int expectedMinute;
 
 	private String description;
 
 	private String image;
+
+	@Setter
 	@ManyToOne(fetch = FetchType.LAZY)
 	private Store store;
 
 	@OneToMany(mappedBy = "storeMenu")
-	private Collection<Reservation> reservations = new ArrayList<>();
+	private final Collection<Reservation> reservations = new ArrayList<>();
+
+	public void updateMenu(int price, int expectedMinute, String description, String image) {
+		this.price = price;
+		this.expectedMinute = expectedMinute;
+		this.description = description;
+		this.image = image;
+	}
+
+	@Builder
+	@SuppressWarnings("unused")
+	public StoreMenu(int price, int expectedMinute, String description, String image) {
+		this.price = price;
+		this.expectedMinute = expectedMinute;
+		this.description = description;
+		this.image = image;
+	}
 
 }

--- a/src/main/java/me/washcar/wcnc/domain/store/entity/menu/service/StoreMenuService.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/entity/menu/service/StoreMenuService.java
@@ -1,0 +1,92 @@
+package me.washcar.wcnc.domain.store.entity.menu.service;
+
+import java.util.List;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import me.washcar.wcnc.domain.store.dao.StoreRepository;
+import me.washcar.wcnc.domain.store.entity.Store;
+import me.washcar.wcnc.domain.store.entity.menu.dao.StoreMenuRepository;
+import me.washcar.wcnc.domain.store.entity.menu.dto.request.MenuRequestDto;
+import me.washcar.wcnc.domain.store.entity.menu.dto.response.MenuResponseDto;
+import me.washcar.wcnc.domain.store.entity.menu.dto.response.MenusDto;
+import me.washcar.wcnc.domain.store.entity.menu.entity.StoreMenu;
+import me.washcar.wcnc.domain.store.service.StoreService;
+import me.washcar.wcnc.global.error.BusinessError;
+import me.washcar.wcnc.global.error.BusinessException;
+
+@Service
+@RequiredArgsConstructor
+public class StoreMenuService {
+
+	public static final int MAX_MENU_NUMBER = 64;
+
+	private final StoreService storeService;
+
+	private final StoreRepository storeRepository;
+
+	private final StoreMenuRepository storeMenuRepository;
+
+	private final ModelMapper modelMapper;
+
+	@Transactional
+	public void create(String slug, MenuRequestDto requestDto) {
+		Store store = storeRepository.findBySlug(slug).orElseThrow(() -> new BusinessException(
+			BusinessError.STORE_NOT_FOUND));
+		storeService.checkStoreChangePermit(store);
+		if (store.getStoreMenus().size() >= MAX_MENU_NUMBER) {
+			throw new BusinessException(BusinessError.EXCEED_STORE_MENU_LIMIT);
+		}
+		StoreMenu storeMenu = StoreMenu.builder()
+			.price(requestDto.getPrice())
+			.expectedMinute(requestDto.getExpectedMinute())
+			.description(requestDto.getDescription())
+			.image(requestDto.getImage())
+			.build();
+		store.addStoreMenu(storeMenu);
+	}
+
+	@Transactional(readOnly = true)
+	public MenusDto getMenusBySlug(String slug) {
+		Store store = storeRepository.findBySlug(slug).orElseThrow(() -> new BusinessException(
+			BusinessError.STORE_NOT_FOUND));
+		List<StoreMenu> storeMenus = store.getStoreMenus();
+		List<MenuResponseDto> menuResponseDtos = storeMenus.stream()
+			.map(m -> modelMapper.map(m, MenuResponseDto.class))
+			.toList();
+		return new MenusDto(menuResponseDtos);
+	}
+
+	@Transactional(readOnly = true)
+	public MenuResponseDto getMenuByUuid(String uuid) {
+		StoreMenu storeMenu = storeMenuRepository.findByUuid(uuid)
+			.orElseThrow(() -> new BusinessException(BusinessError.STORE_MENU_NOT_FOUND));
+		return modelMapper.map(storeMenu, MenuResponseDto.class);
+	}
+
+	@Transactional
+	public void putMenuByUuid(String uuid, MenuRequestDto requestDto) {
+		StoreMenu storeMenu = storeMenuRepository.findByUuid(uuid)
+			.orElseThrow(() -> new BusinessException(BusinessError.STORE_MENU_NOT_FOUND));
+		Store store = storeMenu.getStore();
+		storeService.checkStoreChangePermit(store);
+		storeMenu.updateMenu(requestDto.getPrice(),
+			requestDto.getExpectedMinute(),
+			requestDto.getDescription(),
+			requestDto.getImage()
+		);
+	}
+
+	@Transactional
+	public void deleteMenuByUuid(String uuid) {
+		StoreMenu storeMenu = storeMenuRepository.findByUuid(uuid)
+			.orElseThrow(() -> new BusinessException(BusinessError.STORE_MENU_NOT_FOUND));
+		Store store = storeMenu.getStore();
+		storeService.checkStoreChangePermit(store);
+		store.deleteStoreMenu(storeMenu);
+	}
+
+}

--- a/src/main/java/me/washcar/wcnc/global/configuration/security/SecurityConfiguration.java
+++ b/src/main/java/me/washcar/wcnc/global/configuration/security/SecurityConfiguration.java
@@ -117,6 +117,22 @@ public class SecurityConfiguration {
 			.requestMatchers(HttpMethod.DELETE, "/v2/image/*")
 			.permitAll()
 
+			// StoreMenuController
+			.requestMatchers(HttpMethod.POST, "/v2/store/*/menu")
+			.permitAll()
+
+			.requestMatchers(HttpMethod.GET, "/v2/store/*/menu")
+			.permitAll()
+
+			.requestMatchers(HttpMethod.GET, "/v2/menu/*")
+			.permitAll()
+
+			.requestMatchers(HttpMethod.PUT, "/v2/menu/*")
+			.permitAll()
+
+			.requestMatchers(HttpMethod.DELETE, "/v2/menu/*")
+			.permitAll()
+
 			// Any Request
 			.anyRequest()
 			.permitAll();

--- a/src/main/java/me/washcar/wcnc/global/error/BusinessError.java
+++ b/src/main/java/me/washcar/wcnc/global/error/BusinessError.java
@@ -21,9 +21,11 @@ public enum BusinessError {
 	STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "세차장을 찾을 수 없습니다."),
 	STORE_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 해당 SLUG를 가진 세차장이 존재합니다."),
 	EXCEED_STORE_IMAGE_LIMIT(HttpStatus.CONFLICT, "이미지 최대 등록 가능 횟수를 초과했습니다."),
+	EXCEED_STORE_MENU_LIMIT(HttpStatus.CONFLICT, "메뉴 최대 등록 가능 횟수를 초과했습니다."),
 	FORBIDDEN_STORE_CHANGE(HttpStatus.FORBIDDEN, "해당 세차장의 정보 수정을 할 권한이 없습니다."),
 	FORBIDDEN_MEMBER_CHANGE(HttpStatus.FORBIDDEN, "해당 멤버의 정보 수정을 할 권한이 없습니다."),
 	STORE_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "세차장 이미지를 찾을 수 없습니다."),
+	STORE_MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "세차장 메뉴를 찾을 수 없습니다."),
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/test/java/me/washcar/wcnc/domain/store/entity/image/service/StoreImageServiceTest.java
+++ b/src/test/java/me/washcar/wcnc/domain/store/entity/image/service/StoreImageServiceTest.java
@@ -23,20 +23,20 @@ import me.washcar.wcnc.domain.store.entity.Store;
 import me.washcar.wcnc.domain.store.entity.image.StoreImageTestHelper;
 import me.washcar.wcnc.domain.store.entity.image.dao.StoreImageRepository;
 import me.washcar.wcnc.domain.store.entity.image.dto.request.ImageRequestDto;
+import me.washcar.wcnc.domain.store.service.StoreService;
 import me.washcar.wcnc.global.error.BusinessException;
-import me.washcar.wcnc.global.utility.AuthorizationHelper;
 
 @ExtendWith(MockitoExtension.class)
 class StoreImageServiceTest {
+
+	@Mock
+	private StoreService storeService;
 
 	@Mock
 	private StoreRepository storeRepository;
 
 	@Mock
 	private StoreImageRepository storeImageRepository;
-
-	@Mock
-	private AuthorizationHelper authorizationHelper;
 
 	private static StoreTestHelper storeTestHelper;
 
@@ -52,7 +52,7 @@ class StoreImageServiceTest {
 
 	@BeforeEach
 	void beforeEach() {
-		storeImageService = new StoreImageService(storeRepository, storeImageRepository, authorizationHelper,
+		storeImageService = new StoreImageService(storeService, storeRepository, storeImageRepository,
 			new ModelMapper());
 	}
 

--- a/src/test/java/me/washcar/wcnc/domain/store/entity/menu/StoreMenuTestHelper.java
+++ b/src/test/java/me/washcar/wcnc/domain/store/entity/menu/StoreMenuTestHelper.java
@@ -1,0 +1,17 @@
+package me.washcar.wcnc.domain.store.entity.menu;
+
+import me.washcar.wcnc.domain.store.entity.menu.dto.request.MenuRequestDto;
+
+public class StoreMenuTestHelper {
+	
+	public MenuRequestDto makeStaticMenuRequestDto() {
+		return MenuRequestDto
+			.builder()
+			.price(35000)
+			.expectedMinute(60)
+			.description("testMenuDescription")
+			.image("/store/test/menu01")
+			.build();
+	}
+
+}

--- a/src/test/java/me/washcar/wcnc/domain/store/entity/menu/service/StoreMenuServiceTest.java
+++ b/src/test/java/me/washcar/wcnc/domain/store/entity/menu/service/StoreMenuServiceTest.java
@@ -1,0 +1,116 @@
+package me.washcar.wcnc.domain.store.entity.menu.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+
+import me.washcar.wcnc.domain.store.StoreTestHelper;
+import me.washcar.wcnc.domain.store.dao.StoreRepository;
+import me.washcar.wcnc.domain.store.entity.Store;
+import me.washcar.wcnc.domain.store.entity.menu.StoreMenuTestHelper;
+import me.washcar.wcnc.domain.store.entity.menu.dao.StoreMenuRepository;
+import me.washcar.wcnc.domain.store.entity.menu.dto.request.MenuRequestDto;
+import me.washcar.wcnc.domain.store.service.StoreService;
+import me.washcar.wcnc.global.error.BusinessException;
+
+@ExtendWith(MockitoExtension.class)
+class StoreMenuServiceTest {
+
+	@Mock
+	private StoreService storeService;
+
+	@Mock
+	private StoreRepository storeRepository;
+
+	@Mock
+	private StoreMenuRepository storeMenuRepository;
+
+	private static StoreTestHelper storeTestHelper;
+
+	private static StoreMenuTestHelper storeMenuTestHelper;
+
+	private StoreMenuService storeMenuService;
+
+	@BeforeAll
+	static void beforeAll() {
+		storeTestHelper = new StoreTestHelper();
+		storeMenuTestHelper = new StoreMenuTestHelper();
+	}
+
+	@BeforeEach
+	void beforeEach() {
+		storeMenuService = new StoreMenuService(storeService, storeRepository, storeMenuRepository,
+			new ModelMapper());
+	}
+
+	@Nested
+	@DisplayName("세차장 메뉴 생성 요청하기")
+	class create {
+
+		@Test
+		@DisplayName("세차장이 존재하지 않는 경우 세차장 메뉴 생성 요청에 실패한다")
+		void should_failToPutStoreMenu_when_storeNotExist() {
+			//given
+			MenuRequestDto menuRequestDto = storeMenuTestHelper.makeStaticMenuRequestDto();
+			given(storeRepository.findBySlug(anyString())).willReturn(Optional.empty());
+
+			//when & then
+			assertThatThrownBy(() -> storeMenuService.create("badStoreSlug", menuRequestDto))
+				.isInstanceOf(BusinessException.class);
+		}
+
+		@Test
+		@DisplayName("세차장의 메뉴 최대 등록 가능 수를 초과하는 경우 세차장 메뉴 생성 요청에 실패한다")
+		void should_failToPutStoreMenu_when_exceedStoreImageLimit() {
+			//given
+			MenuRequestDto menuRequestDto = storeMenuTestHelper.makeStaticMenuRequestDto();
+			Store store = storeTestHelper.makeStaticRunningStore();
+			given(storeRepository.findBySlug(anyString())).willReturn(Optional.of(store));
+
+			//when & then
+			for (int i = 0; i < 64; i++) {
+				storeMenuService.create("goodStoreSlug", menuRequestDto);
+			}
+			assertThatThrownBy(() -> storeMenuService.create("goodStoreSlug", menuRequestDto))
+				.isInstanceOf(BusinessException.class);
+		}
+
+	}
+
+	@Nested
+	@DisplayName("세차장 메뉴 목록 가져오기")
+	@Disabled
+	class getMenusBySlug {
+	}
+
+	@Nested
+	@DisplayName("개별 메뉴 가져오기")
+	@Disabled
+	class getMenuByUuid {
+	}
+
+	@Nested
+	@DisplayName("메뉴 수정하기")
+	@Disabled
+	class putMenuByUuid {
+	}
+
+	@Nested
+	@DisplayName("메뉴 삭제하기")
+	@Disabled
+	class deleteMenuByUuid {
+	}
+}


### PR DESCRIPTION
## 🔥 관련 이슈

없음

## 📝 작업 상세 설명

Store Menu 도메인의 CRUD api 및 테스트 코드를 구현하였습니다.
메뉴 최대 등록 가능 개수를 64개로 제한하였습니다.

다음 API들을 구현하였습니다:

- [x]  해당 세차장 메뉴 생성
- [x]  해당 세차장의 모든 메뉴 조회
- [x]  해당 세차장 해당 메뉴 조회
- [x]  해당 세차장 해당 메뉴 수정
- [x]  해당 세차장 해당 메뉴 삭제 *HARD DELETE

## ⭐ 리뷰 요구 사항

없음