### PR TITLE
feature: 세차장 SLUG 중복 검사 API 생성

### DIFF
--- a/src/main/java/me/washcar/wcnc/domain/search/slug/controller/SearchSlugController.java
+++ b/src/main/java/me/washcar/wcnc/domain/search/slug/controller/SearchSlugController.java
@@ -6,10 +6,12 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import lombok.RequiredArgsConstructor;
 import me.washcar.wcnc.domain.search.slug.dto.response.SlugsDto;
 import me.washcar.wcnc.domain.search.slug.service.SearchSlugService;
+import me.washcar.wcnc.domain.store.service.StoreService;
 
 @Controller
 @RequestMapping("/v2/search/slugs")
@@ -17,6 +19,16 @@ import me.washcar.wcnc.domain.search.slug.service.SearchSlugService;
 public class SearchSlugController {
 
 	private final SearchSlugService searchSlugService;
+
+	private final StoreService storeService;
+
+	@GetMapping
+	public ResponseEntity<Void> checkSlugSafety(@RequestParam("slug") String slug) {
+		storeService.checkNewSlugSafety(slug);
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.build();
+	}
 
 	@GetMapping("/me")
 	public ResponseEntity<?> getMyStoreSlugs(@AuthenticationPrincipal String uuid) {

--- a/src/main/java/me/washcar/wcnc/domain/store/service/StoreService.java
+++ b/src/main/java/me/washcar/wcnc/domain/store/service/StoreService.java
@@ -32,15 +32,16 @@ public class StoreService {
 
 	private final ModelMapper modelMapper;
 
-	private void checkNewSlugSafety(StoreRequestDto storeRequestDto) {
-		if (storeRepository.existsBySlug(storeRequestDto.getSlug())) {
+	@Transactional(readOnly = true)
+	public void checkNewSlugSafety(String slug) {
+		if (storeRepository.existsBySlug(slug)) {
 			throw new BusinessException(BusinessError.STORE_ALREADY_EXIST);
 		}
 	}
 
-	private void checkChangeSlugSafety(String slug, StoreRequestDto storeRequestDto) {
+	public void checkChangeSlugSafety(String slug, StoreRequestDto storeRequestDto) {
 		if (!storeRequestDto.getSlug().equals(slug)) {
-			checkNewSlugSafety(storeRequestDto);
+			checkNewSlugSafety(storeRequestDto.getSlug());
 		}
 	}
 
@@ -60,7 +61,7 @@ public class StoreService {
 
 	@Transactional
 	public void postStore(StoreRequestDto storeRequestDto, String ownerUuid) {
-		checkNewSlugSafety(storeRequestDto);
+		checkNewSlugSafety(storeRequestDto.getSlug());
 		Store store = Store.builder()
 			.slug(storeRequestDto.getSlug())
 			.location(storeRequestDto.getLocation())


### PR DESCRIPTION
## 🔥 관련 이슈

없음

## 📝 작업 상세 설명

API 구현:
- [x] 세차장 신규 생성 시의 SLUG 중복 여부 검색

## ⭐ 리뷰 요구 사항

기존 세차장 정보 변경 로직에서 사용하던 서비스 메소드 `checkNewSlugSafety()` 를 직접 접근하는 컨트롤러를 만들었습니다. non-transactional public 메소드에서 호출한 public transactional 메소드는 `@Transactional` 이 작동하지 않기 때문에, 앞으로 해당 메소드를 기존 사용법처럼 다른 서비스 메소드에서 호출 할 때 `checkNewSlugSafety()` 이 경우에 따라 트랜잭셔널 하지 않을 수 있음에 유의해야 합니다.

```JAVA
@Transactional(readOnly = true)
public void checkNewSlugSafety(String slug) {
  if (storeRepository.existsBySlug(slug)) {
	  throw new BusinessException(BusinessError.STORE_ALREADY_EXIST);
  }
}
```
